### PR TITLE
Fixed so importing from typing_extensions for earlier python versions.

### DIFF
--- a/pyaml/magnet/magnet.py
+++ b/pyaml/magnet/magnet.py
@@ -4,7 +4,10 @@ from ..control.deviceaccess import DeviceAccess
 from ..control import abstract
 from .model import MagnetModel
 from scipy.constants import speed_of_light
-from typing import Self
+try:
+    from typing import Self  # Python 3.11+
+except ImportError:
+    from typing_extensions import Self  # Python 3.10 and earlier
 import numpy as np
 
 class MagnetConfigModel(ElementConfigModel):


### PR DESCRIPTION
`from typing import Self` only works from python 3.11. For earlier versions `from typing_extensions import Self` has to be used. I added a fix for it but maybe there is some better way to handle compatibility for different python versions.