### PR TITLE
Fix missing root path for example.

### DIFF
--- a/examples/ESRF_tune_example/esrf_tune_example_no_yaml.py
+++ b/examples/ESRF_tune_example/esrf_tune_example_no_yaml.py
@@ -7,10 +7,23 @@ from pyaml.arrays.magnet import Magnet,ConfigModel as MagnetArrayConfigModel
 from tango.pyaml.controlsystem import TangoControlSystem,ConfigModel as ControlSystemConfig
 from tango.pyaml.attribute import Attribute,ConfigModel as AttributeConfig
 from tango.pyaml.attribute_read_only import AttributeReadOnly,ConfigModel as AttributeReadOnlyConfig
+from pyaml.configuration import set_root_folder
+import os
 
 
 import numpy as np
 import time
+
+# Get the directory of the current script
+script_dir = os.path.dirname(__file__)
+
+# Go up one level and then into 'data'
+relative_path = os.path.join(script_dir, '..', '..', 'tests')
+
+# Normalize the path (resolves '..')
+absolute_path = os.path.abspath(relative_path)
+
+set_root_folder(absolute_path)
 
 # Configuration
 


### PR DESCRIPTION
I have added the root path to the `esrf_tune_example_no_yaml.py` example since without it the csv files aren't found when running the example.

However, the example still doesn't work. I get the following error which I guess is because the devices try to connect to TANGO devices that don't exist.

```
PyAMLException: API_CorbaException: TRANSIENT CORBA system exception: TRANSIENT_NoUsableProfile Origin: void Tango::Connection::connect(const string&) at (/src/cppTango/src/client/devapi_base.cpp:635) Severity: ERR
```