### PR TITLE
Fixed wrong array type in dummy CS

### DIFF
--- a/tests/dummy_cs/tango-pyaml/tango/pyaml/multi_attribute.py
+++ b/tests/dummy_cs/tango-pyaml/tango/pyaml/multi_attribute.py
@@ -66,10 +66,10 @@ class MultiAttribute(DeviceAccessList):
 
     def get(self) -> npt.NDArray[np.float64]:
         print(f"MultiAttribute.get({len(self)} values)")
-        return [a.get() for a in self]
+        return np.array([a.get() for a in self])
 
     def readback(self) -> np.array:
-        return []
+        return np.array([])
 
     def unit(self) -> list[str]:
         return [a.unit() for a in self]

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -176,6 +176,9 @@ def test_arrays(install_test_package):
     assert(np.abs(strHVSQ[4] + 0.000017)<1e-10)   # V
     assert(np.abs(strHVSQ[5] - 1e-6)<1e-10)        # SQ
 
+    bpmsLive = BPMArray("",sr.live.get_all_bpms())
+    bpmsLive.positions.get()
+
     Factory.clear()
 
     # Test dynamic arrays


### PR DESCRIPTION
This PR solve a bug in the dummy CS triggered by the BPMArray.

```bash
>           return self.__aggregator.get().reshape(len(self.__bpms),2)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           AttributeError: 'list' object has no attribute 'reshape'

pyaml/arrays/bpm_array.py:20: AttributeError
```