### PR TITLE
Added facility and updated name to machine.

### DIFF
--- a/pyaml/accelerator.py
+++ b/pyaml/accelerator.py
@@ -1,5 +1,5 @@
 """
-Instrument class
+Accelerator class
 """
 
 from pydantic import BaseModel, ConfigDict
@@ -17,13 +17,15 @@ PYAMLCLASS = "Accelerator"
 class ConfigModel(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
-    name: str
-    """Instrument name"""
+    facility: str
+    "Facility name"
+    machine: str
+    """Accelerator name"""
     energy: float
-    """Instrument nominal energy, for ramped machine,
+    """Accelerator nominal energy, for ramped machine,
        this value can be dynamically set"""
     controls: list[ControlSystem] = None
-    """List of control system used, an instrument
+    """List of control system used, an accelerator
        can access several control systems"""
     simulators: list[Simulator] = None
     """Simulator list"""

--- a/tests/config/EBSOrbit.yaml
+++ b/tests/config/EBSOrbit.yaml
@@ -1,6 +1,6 @@
-type: pyaml.pyaml
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/EBSTune.yaml
+++ b/tests/config/EBSTune.yaml
@@ -1,5 +1,6 @@
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/EBS_rf.yaml
+++ b/tests/config/EBS_rf.yaml
@@ -1,5 +1,6 @@
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/EBS_rf_multi.yaml
+++ b/tests/config/EBS_rf_multi.yaml
@@ -1,5 +1,6 @@
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/EBS_rf_notrans.yaml
+++ b/tests/config/EBS_rf_notrans.yaml
@@ -1,5 +1,6 @@
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/bad_conf.yml
+++ b/tests/config/bad_conf.yml
@@ -1,7 +1,8 @@
 type: pyaml.pyaml
 instruments:
   - type: pyaml.instrument
-    name: sr
+    facility: ESRF
+    machine: sr
     energy: 6e9
     simulators:
       - type: pyalkqln # Error here

--- a/tests/config/bad_conf_cycles.json
+++ b/tests/config/bad_conf_cycles.json
@@ -1,6 +1,7 @@
 {
     "type": "pyaml.accelerator",
-    "name": "sr",
+    "facility": "ESRF",
+    "machine": "sr",
     "energy": 6e9,
     "simulators": ["../config/bad_conf_cycles.json"],
     "data_folder": "/data/store",

--- a/tests/config/bad_conf_cycles.yml
+++ b/tests/config/bad_conf_cycles.yml
@@ -1,5 +1,6 @@
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/bad_conf_duplicate_1.yaml
+++ b/tests/config/bad_conf_duplicate_1.yaml
@@ -1,5 +1,6 @@
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/bad_conf_duplicate_2.yaml
+++ b/tests/config/bad_conf_duplicate_2.yaml
@@ -1,6 +1,6 @@
-type: pyaml.pyaml
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/bad_conf_duplicate_3.yaml
+++ b/tests/config/bad_conf_duplicate_3.yaml
@@ -1,5 +1,6 @@
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/bpms.yaml
+++ b/tests/config/bpms.yaml
@@ -1,5 +1,6 @@
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/sr-attribute-linker.yaml
+++ b/tests/config/sr-attribute-linker.yaml
@@ -1,5 +1,6 @@
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/sr-ident-cfm.yaml
+++ b/tests/config/sr-ident-cfm.yaml
@@ -1,5 +1,6 @@
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/sr-ident-hw-only.yaml
+++ b/tests/config/sr-ident-hw-only.yaml
@@ -1,5 +1,6 @@
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/sr-ident-strgth-only.yaml
+++ b/tests/config/sr-ident-strgth-only.yaml
@@ -1,5 +1,6 @@
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/sr.yaml
+++ b/tests/config/sr.yaml
@@ -1,6 +1,6 @@
-type: pyaml.pyaml
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/config/tune_monitor.yaml
+++ b/tests/config/tune_monitor.yaml
@@ -1,5 +1,6 @@
 type: pyaml.accelerator
-name: sr
+facility: ESRF
+machine: sr
 energy: 6e9
 simulators:
   - type: pyaml.lattice.simulator

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -25,7 +25,7 @@ def test_tune(install_test_package):
     with pytest.raises(PyAMLConfigException) as exc:
         ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_3.yaml")
     assert "element BPM_C04-06 already defined" in str(exc)
-    assert "line 57, column 3" in str(exc)
+    assert "line 58, column 3" in str(exc)
     Factory.clear()
 
     sr: Accelerator = Accelerator.load("tests/config/EBSTune.yaml")

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -34,7 +34,7 @@ def test_error_location(test_file):
     print(str(exc.value))
     test_file_names = test_file.split("/")
     test_file_name = test_file_names[len(test_file_names) - 1]
-    assert f"{test_file_name} at line 7, column 9" in str(exc.value)
+    assert f"{test_file_name} at line 8, column 9" in str(exc.value)
 
 
 @pytest.mark.parametrize(
@@ -50,4 +50,4 @@ def test_error_cycles(test_file):
 
     assert "Circular file inclusion of " in str(exc.value)
     if not test_file.endswith(".json"):
-        assert "at line 21" in str(exc.value)
+        assert "at line 22" in str(exc.value)


### PR DESCRIPTION
I have done three changes:

- Added a field `facility` to the `Accelerator` that could be used in metadata to know at which facility a specific dataset was produced at. It's also needed for labs that run more than one facility.

- Suggested to change `name` in `Accelerator` to `machine` to make it easier to understand what the field means when there is also the `facility` field.

- Cleaned up remains from when `Instrument` was changed to `Accelerator`. 