### PR TITLE
Make compatible with python 3.10.

### DIFF
--- a/pyaml/tuning_tools/orbit.py
+++ b/pyaml/tuning_tools/orbit.py
@@ -1,6 +1,12 @@
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Optional, Self
+from typing import TYPE_CHECKING, Literal, Optional
+
+try:
+    from typing import Self  # Python 3.11+
+except ImportError:
+    from typing_extensions import Self  # Python 3.10 and earlier
+
 
 from pydantic import BaseModel, ConfigDict
 


### PR DESCRIPTION
Current `orbit.py` is not compatible with Python 3.10 which some labs still have in their control rooms.