### PR TITLE
Added tune property

### DIFF
--- a/pyaml/common/element_holder.py
+++ b/pyaml/common/element_holder.py
@@ -200,6 +200,10 @@ class ElementHolder(object):
     def add_tune_tuning(self, tune: Element):
         self.__add(self.__TUNING_TOOLS, tune)
 
+    @property
+    def tune(self) -> "Tune":
+        return self.get_tune_tuning("DEFAULT_TUNE_CORRECTION")
+
     def get_orbit_tuning(self, name: str) -> "Orbit":
         return self.__get("Orbit tuning tool", name, self.__TUNING_TOOLS)
 

--- a/tests/config/EBSTune.yaml
+++ b/tests/config/EBSTune.yaml
@@ -1887,7 +1887,7 @@ devices:
     attribute: srdiag/beam-tune/main/Qv
     unit: mm
 - type: pyaml.tuning_tools.tune
-  name: TUNE
+  name: DEFAULT_TUNE_CORRECTION
   quad_array: QForTune
   betatron_tune: BETATRON_TUNE
   delta: 1e-4

--- a/tests/test_tuning_tools.py
+++ b/tests/test_tuning_tools.py
@@ -16,12 +16,11 @@ def tune_callback(step: int, action: int, m: Magnet, dtune: np.array):
 def test_tuning_tools():
     sr = Accelerator.load("tests/config/EBSTune.yaml", use_fast_loader=False)
     sr.design.get_lattice().disable_6d()
-    tune_adjust = sr.design.get_tune_tuning("TUNE")
-    tune_adjust.response.measure(callback=tune_callback)
-    tune_adjust.response.save_json("tunemat.json")
-    tune_adjust.response.load_json("tunemat.json")
-    tune_adjust.set([0.17, 0.32], iter=2)
-    tune = tune_adjust.readback()
+    sr.design.tune.response.measure(callback=tune_callback)
+    sr.design.tune.response.save_json("tunemat.json")
+    sr.design.tune.response.load_json("tunemat.json")
+    sr.design.tune.set([0.17, 0.32], iter=2)
+    tune = sr.design.tune.readback()
     assert np.abs(tune[0] - 0.17) < 1e-5
     assert np.abs(tune[1] - 0.32) < 1e-5
 


### PR DESCRIPTION
This PR add tune property to allow the writting below:
```python
    sr.design.tune.response.measure(callback=tune_callback)
    sr.design.tune.response.save_json("tunemat.json")
    sr.design.tune.response.load_json("tunemat.json")
    sr.design.tune.set([0.17, 0.32], iter=2)
    tune = sr.design.tune.readback()
```