### PR TITLE
ESRF tune example proposal

### DIFF
--- a/examples/ESRF_tune_example/README.md
+++ b/examples/ESRF_tune_example/README.md
@@ -15,3 +15,14 @@
   1. navigate to the pyaml root directory 
   1. Download (or clone) the example files. 
 
+  ## expected output is
+
+  30 Jan 2026, 09:23:13 | WARNING | PyAML Tango control system binding (0.3.2) initialized with name 'live' and TANGO_HOST=ebs-simu-3:10000
+  Tune response: #0 QD2E-C04 [ 0.17851726 -1.25993589]
+  Tune response: #1 QD2A-C05 [ 0.17889514 -1.25969115]
+  ...
+  Tune response: #123 QF1A-C03 [ 0.59069308 -0.49430245]
+  Initial tune: [0.16000001 0.33999986]
+  Final tune: [0.17 0.32]
+
+

--- a/examples/ESRF_tune_example/README.md
+++ b/examples/ESRF_tune_example/README.md
@@ -16,11 +16,16 @@
    ```
 
   ## Run the examples
+  Two examples are available for tune correction.
+  The esrf_tune_example.py  shows the standard usage
+  The esrf_tune_example_no_yaml.py  shows the same but without using configuration file.
 
-  1. navigate to the pyaml root directory 
-  1. Download (or clone) the example files. 
+  To run the examples:
+  1. navigate to the pyaml root directory
+  2. Download (or clone) the example files.
+  3. run the files
 
-  ## expected output for SR.design is
+  ## expected output of esrf_tune_example.py for SR.design is
 
   30 Jan 2026, 09:23:13 | WARNING | PyAML Tango control system binding (0.3.2) initialized with name 'live' and TANGO_HOST=ebs-simu-3:10000
   Tune response: #0 QD2E-C04 [ 0.17851726 -1.25993589]
@@ -31,7 +36,7 @@
   Final tune: [0.17 0.32]
 
 
-  ## expected output for SR.live is
+  ## expected output of esrf_tune_example.py for SR.live is
   Initial tune: [0. 0.]
   MultiAttribute.get(124 values)
   MultiAttribute.get(124 values)
@@ -41,3 +46,16 @@
   //ebs-simu-3:10000/srmag/vps-qf1/c02-e/current:1.3024074153237937
   //ebs-simu-3:10000/srmag/vps-qf1/c03-a/current:1.2966875742108155
   Final tune: [0. 0.]
+
+  ## expected output of: esrf_tune_example_no_yaml.py
+
+  Creating dummy TangoControlSystem: live
+  Tune=Value(0.0, quality='VALID',timestamp='2026-01-30 10:14:20.685681'), Value(0.0, quality='VALID',timestamp='2026-01-30 10:14:20.685764')
+  MultiAttribute.get(4 values)
+  MultiAttribute.get(4 values)
+  MultiAttribute.set(4 values)
+  //ebs-simu-3:10000/srmag/vps-qf1/c01-a/current:9.77449643229055
+  //ebs-simu-3:10000/srmag/vps-qf1/c01-e/current:9.724114177375114
+  //ebs-simu-3:10000/srmag/vps-qd2/c01-a/current:7.785894751522811
+  //ebs-simu-3:10000/srmag/vps-qd2/c01-e/current:7.778613675036138
+  Tune=Value(0.0, quality='VALID',timestamp='2026-01-30 10:14:23.686925'), Value(0.0, quality='VALID',timestamp='2026-01-30 10:14:23.686994')

--- a/examples/ESRF_tune_example/README.md
+++ b/examples/ESRF_tune_example/README.md
@@ -1,0 +1,15 @@
+# Instructions for how to run the ESRF Tune example.
+
+## Install pyAML
+
+1. Create a virtual environment and activate it. It needs to have >= Python 3.11.
+
+2. Install pyAML including the ophyd-async EPICS bindings.
+
+  ```bash
+  pip install accelerator-middle-layer[tango]
+  ```
+
+  ## Run the examples
+
+  1. Download (or clone) the example files. 

--- a/examples/ESRF_tune_example/README.md
+++ b/examples/ESRF_tune_example/README.md
@@ -4,18 +4,23 @@
 
 1. Create a virtual environment and activate it. It needs to have >= Python 3.11.
 
-2. Install pyAML including the ophyd-async EPICS bindings.
+2. Install pyAML including the tango bindings.
 
   ```bash
   pip install accelerator-middle-layer[tango]
   ```
+
+3. install EBS dummy Control system. This is valid untill an ESRF virtual machine will be available as for BESSYII and SOLEIL
+   ```bash
+   pip install tests/dummy_cs/tango-pyaml
+   ```
 
   ## Run the examples
 
   1. navigate to the pyaml root directory 
   1. Download (or clone) the example files. 
 
-  ## expected output is
+  ## expected output for SR.design is
 
   30 Jan 2026, 09:23:13 | WARNING | PyAML Tango control system binding (0.3.2) initialized with name 'live' and TANGO_HOST=ebs-simu-3:10000
   Tune response: #0 QD2E-C04 [ 0.17851726 -1.25993589]
@@ -26,3 +31,13 @@
   Final tune: [0.17 0.32]
 
 
+  ## expected output for SR.live is
+  Initial tune: [0. 0.]
+  MultiAttribute.get(124 values)
+  MultiAttribute.get(124 values)
+  MultiAttribute.set(124 values)
+  //ebs-simu-3:10000/srmag/vps-qd2/c04-e/current:0.8688600876142427
+  ...
+  //ebs-simu-3:10000/srmag/vps-qf1/c02-e/current:1.3024074153237937
+  //ebs-simu-3:10000/srmag/vps-qf1/c03-a/current:1.2966875742108155
+  Final tune: [0. 0.]

--- a/examples/ESRF_tune_example/README.md
+++ b/examples/ESRF_tune_example/README.md
@@ -12,4 +12,6 @@
 
   ## Run the examples
 
+  1. navigate to the pyaml root directory 
   1. Download (or clone) the example files. 
+

--- a/examples/ESRF_tune_example/esrf_tune_example.py
+++ b/examples/ESRF_tune_example/esrf_tune_example.py
@@ -6,11 +6,12 @@ from pyaml.accelerator import Accelerator
 from pyaml.common.constants import ACTION_RESTORE
 from pyaml.magnet.magnet import Magnet
 
-sr: Accelerator = Accelerator.load('./pyaml/tests/config/EBSTune.yaml')
+sr: Accelerator = Accelerator.load('./tests/config/EBSTune.yaml')
 sr.design.get_lattice().disable_6d()
 
 # switch script from live to design
-SR = sr.design # acts on simulations sr.live to act on real machine 
+# sr.design acts on simulations sr.live to act on real machine 
+SR = sr.design 
 
 
 # Callback exectued after each magnet strenght setting

--- a/examples/ESRF_tune_example/esrf_tune_example.py
+++ b/examples/ESRF_tune_example/esrf_tune_example.py
@@ -24,13 +24,13 @@ def tune_callback(step: int, action: int, m: Magnet, dtune: np.array):
 
 
 # Compute tune response matrix
-tune_adjust_design = sr.design.get_tune_tuning("TUNE")
+tune_adjust_design = sr.design.tune
 tune_adjust_design.response.measure(callback=tune_callback)
 tune_adjust_design.response.save_json("tunemat.json")
 
 # Correct tune on live or design
-tune_adjust = SR.get_tune_tuning("TUNE")
+tune_adjust = SR.tune
 tune_adjust.response.load_json("tunemat.json")
-print(tune_adjust.readback())
+print(f'Initial tune: {tune_adjust.readback()}')
 tune_adjust.set([0.17, 0.32], iter=2, wait_time=10)
-print(tune_adjust.readback())
+print(f'Final tune: {tune_adjust.readback()}')

--- a/examples/ESRF_tune_example/esrf_tune_example.py
+++ b/examples/ESRF_tune_example/esrf_tune_example.py
@@ -11,7 +11,7 @@ sr.design.get_lattice().disable_6d()
 
 # switch script from live to design
 # sr.design acts on simulations sr.live to act on real machine 
-SR = sr.design 
+MACH = sr.design 
 
 
 # Callback exectued after each magnet strenght setting
@@ -29,7 +29,7 @@ tune_adjust_design.response.measure(callback=tune_callback)
 tune_adjust_design.response.save_json("tunemat.json")
 
 # Correct tune on live or design
-tune_adjust = SR.tune
+tune_adjust = MACH.tune
 tune_adjust.response.load_json("tunemat.json")
 print(f'Initial tune: {tune_adjust.readback()}')
 tune_adjust.set([0.17, 0.32], iter=2, wait_time=10)

--- a/examples/ESRF_tune_example/esrf_tune_example.py
+++ b/examples/ESRF_tune_example/esrf_tune_example.py
@@ -10,8 +10,7 @@ sr: Accelerator = Accelerator.load('./pyaml/tests/config/EBSTune.yaml')
 sr.design.get_lattice().disable_6d()
 
 # switch script from live to design
-# SR = sr.live   # act on live machine
-SR = sr.design # act on simulation 
+SR = sr.design # acts on simulations sr.live to act on real machine 
 
 
 # Callback exectued after each magnet strenght setting

--- a/examples/ESRF_tune_example/esrf_tune_example.py
+++ b/examples/ESRF_tune_example/esrf_tune_example.py
@@ -6,17 +6,12 @@ from pyaml.accelerator import Accelerator
 from pyaml.common.constants import ACTION_RESTORE
 from pyaml.magnet.magnet import Magnet
 
-# Get the directory of the current script
-script_dir = os.path.dirname(__file__)
-
-# Go up one level and then into 'data'
-relative_path = os.path.join(script_dir, "..", "..", "tests", "config", "EBSTune.yaml")
-
-# Normalize the path (resolves '..')
-absolute_path = os.path.abspath(relative_path)
-
-sr: Accelerator = Accelerator.load(absolute_path)
+sr: Accelerator = Accelerator.load('./pyaml/tests/config/EBSTune.yaml')
 sr.design.get_lattice().disable_6d()
+
+# switch script from live to design
+# SR = sr.live   # act on live machine
+SR = sr.design # act on simulation 
 
 
 # Callback exectued after each magnet strenght setting
@@ -33,9 +28,9 @@ tune_adjust_design = sr.design.get_tune_tuning("TUNE")
 tune_adjust_design.response.measure(callback=tune_callback)
 tune_adjust_design.response.save_json("tunemat.json")
 
-# Correct tune on live
-tune_adjust_live = sr.live.get_tune_tuning("TUNE")
-tune_adjust_live.response.load_json("tunemat.json")
-print(tune_adjust_live.readback())
-tune_adjust_live.set([0.17, 0.32], iter=2, wait_time=10)
-print(tune_adjust_live.readback())
+# Correct tune on live or design
+tune_adjust = SR.get_tune_tuning("TUNE")
+tune_adjust.response.load_json("tunemat.json")
+print(tune_adjust.readback())
+tune_adjust.set([0.17, 0.32], iter=2, wait_time=10)
+print(tune_adjust.readback())

--- a/examples/ESRF_tune_example/esrf_tune_example.py
+++ b/examples/ESRF_tune_example/esrf_tune_example.py
@@ -6,12 +6,12 @@ from pyaml.accelerator import Accelerator
 from pyaml.common.constants import ACTION_RESTORE
 from pyaml.magnet.magnet import Magnet
 
-sr: Accelerator = Accelerator.load('./tests/config/EBSTune.yaml')
+sr: Accelerator = Accelerator.load("./tests/config/EBSTune.yaml")
 sr.design.get_lattice().disable_6d()
 
 # switch script from live to design
-# sr.design acts on simulations sr.live to act on real machine 
-SR = sr.design 
+# sr.design acts on simulations sr.live to act on real machine
+SR = sr.live
 
 
 # Callback exectued after each magnet strenght setting
@@ -31,6 +31,6 @@ tune_adjust_design.response.save_json("tunemat.json")
 # Correct tune on live or design
 tune_adjust = SR.tune
 tune_adjust.response.load_json("tunemat.json")
-print(f'Initial tune: {tune_adjust.readback()}')
+print(f"Initial tune: {tune_adjust.readback()}")
 tune_adjust.set([0.17, 0.32], iter=2, wait_time=10)
-print(f'Final tune: {tune_adjust.readback()}')
+print(f"Final tune: {tune_adjust.readback()}")

--- a/examples/ESRF_tune_example/esrf_tune_example.py
+++ b/examples/ESRF_tune_example/esrf_tune_example.py
@@ -11,7 +11,7 @@ sr.design.get_lattice().disable_6d()
 
 # switch script from live to design
 # sr.design acts on simulations sr.live to act on real machine 
-MACH = sr.design 
+SR = sr.design 
 
 
 # Callback exectued after each magnet strenght setting
@@ -29,7 +29,7 @@ tune_adjust_design.response.measure(callback=tune_callback)
 tune_adjust_design.response.save_json("tunemat.json")
 
 # Correct tune on live or design
-tune_adjust = MACH.tune
+tune_adjust = SR.tune
 tune_adjust.response.load_json("tunemat.json")
 print(f'Initial tune: {tune_adjust.readback()}')
 tune_adjust.set([0.17, 0.32], iter=2, wait_time=10)


### PR DESCRIPTION
This is just a proposal

I have removed the path management part to make the reading lighter and more immediate.

I have also introduced a switch flag to show the MML feature restored and imporved (can access all time any model)

The test however is not running due to an error:

`pyaml.common.exception.PyAMLException: Tune tuning tool TUNE not defined`
