### PR TITLE
missing .orm in last line of example file

### DIFF
--- a/examples/ESRF_ORM_example/measure_ideal_ORM.py
+++ b/examples/ESRF_ORM_example/measure_ideal_ORM.py
@@ -16,4 +16,4 @@ ebs.orm.save(parent_folder / Path("ideal_orm.json"))
 ebs.orm.save(parent_folder / Path("ideal_orm.yaml"), with_type="yaml")
 ebs.orm.save(parent_folder / Path("ideal_orm.npz"), with_type="npz")
 
-ormdata = ebs.get()
+ormdata = ebs.orm.get()


### PR DESCRIPTION
I introduced this error in the latest commits.