### PR TITLE
Clear factory before loading

### DIFF
--- a/pyaml/accelerator.py
+++ b/pyaml/accelerator.py
@@ -153,6 +153,8 @@ class Accelerator(object):
         if ignore_external:
             # control systems are external, so remove controls field
             config_dict.pop("controls", None)
+        # Ensure factory is clean before building a new accelerator
+        Factory.clear()
         return Factory.depth_first_build(config_dict, ignore_external)
 
     @staticmethod

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -9,12 +9,10 @@ from pyaml.arrays.bpm import ConfigModel as BPMArrayConfigModel
 from pyaml.arrays.bpm_array import BPMArray
 from pyaml.arrays.cfm_magnet import CombinedFunctionMagnet
 from pyaml.arrays.cfm_magnet import ConfigModel as CombinedFunctionMagnetConfigModel
-from pyaml.arrays.cfm_magnet_array import CombinedFunctionMagnetArray
 from pyaml.arrays.element_array import ElementArray
 from pyaml.arrays.magnet import ConfigModel as MagnetArrayConfigModel
 from pyaml.arrays.magnet import Magnet
 from pyaml.arrays.magnet_array import MagnetArray
-from pyaml.configuration.factory import Factory
 
 
 @pytest.mark.parametrize(
@@ -205,8 +203,6 @@ def test_arrays(install_test_package):
     bpmsLive = BPMArray("", sr.live.get_all_bpms())
     bpmsLive.positions.get()
 
-    Factory.clear()
-
     # Test dynamic arrays
 
     sr: Accelerator = Accelerator.load(
@@ -244,7 +240,6 @@ def test_arrays(install_test_package):
     v = sr.design.get_cfm_magnets("emptyCFM").strengths.get()  # Ensure good attach
     assert np.shape(v) == (0,)
 
-    Factory.clear()
 
 @pytest.mark.parametrize(
     "sr_file",
@@ -253,7 +248,9 @@ def test_arrays(install_test_package):
     ],
 )
 def test_serialized_magnets_arrays(sr_file):
-    sr: Accelerator = Accelerator.load(sr_file, use_fast_loader=True, ignore_external=True)
+    sr: Accelerator = Accelerator.load(
+        sr_file, use_fast_loader=True, ignore_external=True
+    )
     the_serie = sr.design.get_serialized_magnets("series")
     strength = the_serie.strengths.get()
     assert len(strength) == 5
@@ -263,4 +260,3 @@ def test_serialized_magnets_arrays(sr_file):
     assert len(hardwares) == 5
     print(hardwares)
     the_serie.hardwares.set([10])
-

--- a/tests/test_bpm.py
+++ b/tests/test_bpm.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from pyaml.accelerator import Accelerator
-from pyaml.configuration.factory import Factory
 
 
 def test_simulator_bpm_tilt():
@@ -12,8 +11,6 @@ def test_simulator_bpm_tilt():
     assert bpm.tilt.get() == 0
     bpm.tilt.set(0.01)
     assert bpm.tilt.get() == 0.01
-
-    Factory.clear()
 
 
 def test_simulator_bpm_offset():
@@ -27,8 +24,6 @@ def test_simulator_bpm_offset():
     assert bpm.offset.get()[0] == 0.1
     assert bpm.offset.get()[1] == 0.2
     assert np.allclose(bpm.positions.get(), np.array([0.0, 0.0]))
-
-    Factory.clear()
 
 
 @pytest.mark.parametrize(
@@ -45,8 +40,6 @@ def test_simulator_bpm_position(install_test_package):
     assert np.allclose(bpm.positions.get(), np.array([0.0, 0.0]))
     assert np.allclose(bpm_simple.positions.get(), np.array([0.0, 0.0]))
 
-    Factory.clear()
-
 
 def test_simulator_bpm_position_with_bad_corrector_strength():
     sr: Accelerator = Accelerator.load("tests/config/bpms.yaml", ignore_external=True)
@@ -60,5 +53,3 @@ def test_simulator_bpm_position_with_bad_corrector_strength():
     for bpm in [bpm1, bpm_simple, bpm3]:
         assert bpm.positions.get()[0] != 0.0
         assert bpm.positions.get()[1] != 0.0
-
-    Factory.clear()

--- a/tests/test_bpm_controlsystem.py
+++ b/tests/test_bpm_controlsystem.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from pyaml.accelerator import Accelerator
-from pyaml.configuration.factory import Factory
 
 
 @pytest.mark.parametrize(
@@ -18,8 +17,6 @@ def test_controlsystem_bpm_tilt(install_test_package):
     assert bpm.tilt.get() == 0
     bpm.tilt.set(0.01)
     assert bpm.tilt.get() == 0.01
-
-    Factory.clear()
 
 
 @pytest.mark.parametrize(
@@ -37,8 +34,6 @@ def test_controlsystem_bpm_offset(install_test_package):
     assert bpm.offset.get()[0] == 0.1
     assert bpm.offset.get()[1] == 0.2
     assert np.allclose(bpm.positions.get(), np.array([0.0, 0.0]))
-
-    Factory.clear()
 
 
 @pytest.mark.parametrize(
@@ -65,5 +60,3 @@ def test_controlsystem_bpm_position_indexed(install_test_package):
     bpm = sr.live.get_bpm("BPM_C01-04")
 
     assert np.allclose(bpm.positions.get(), np.array([0.0, 1.0]))
-
-    Factory.clear()

--- a/tests/test_chromaticity_monitor.py
+++ b/tests/test_chromaticity_monitor.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from pyaml.accelerator import Accelerator
-from pyaml.configuration.factory import Factory
 
 
 def test_simulator_chromaticity_monitor():
@@ -19,8 +18,6 @@ def test_simulator_chromaticity_monitor():
         chromaticity_monitor.chromaticity.get()[1]
         == sr.design.get_lattice().get_chrom()[1]
     )
-
-    Factory.clear()
 
 
 @pytest.mark.parametrize(
@@ -44,5 +41,3 @@ def test_controlsystem_chromaticity_monitor(install_test_package):
     ksi = np.abs(chromaticity_monitor.chromaticity.get())
     assert abs(ksi[0]) < 1e-17
     assert abs(ksi[1]) < 1e-17
-
-    Factory.clear()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,7 +3,6 @@ import pytest
 from pyaml.accelerator import Accelerator
 from pyaml.arrays.magnet_array import MagnetArray
 from pyaml.common.exception import PyAMLConfigException, PyAMLException
-from pyaml.configuration.factory import Factory
 
 
 @pytest.mark.parametrize(
@@ -15,18 +14,15 @@ def test_tune(install_test_package):
     with pytest.raises(PyAMLConfigException) as exc:
         ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_1.yaml")
     assert "MagnetArray HCORR : duplicate name SH1A-C02-H @index 2" in str(exc)
-    Factory.clear()
 
     with pytest.raises(PyAMLConfigException) as exc:
         ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_2.yaml")
     assert "BPMArray BPM : duplicate name BPM_C04-06 @index 3" in str(exc)
-    Factory.clear()
 
     with pytest.raises(PyAMLConfigException) as exc:
         ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_3.yaml")
     assert "element BPM_C04-06 already defined" in str(exc)
     assert "line 58, column 3" in str(exc)
-    Factory.clear()
 
     sr: Accelerator = Accelerator.load("tests/config/EBSTune.yaml")
     m1 = sr.live.get_magnet("QF1E-C04")
@@ -45,5 +41,3 @@ def test_tune(install_test_package):
     with pytest.raises(PyAMLException) as exc:
         m2 = sr.design.get_bpm("QF1A-C05XX")
     assert "BPM QF1A-C05XX not defined" in str(exc)
-
-    Factory.clear()

--- a/tests/test_ident_models.py
+++ b/tests/test_ident_models.py
@@ -3,9 +3,7 @@ import pytest
 
 from pyaml.accelerator import Accelerator
 from pyaml.configuration.factory import Factory
-from pyaml.magnet.cfm_magnet import CombinedFunctionMagnet
 from pyaml.magnet.hcorrector import HCorrector
-from pyaml.magnet.model import MagnetModel
 from pyaml.magnet.vcorrector import VCorrector
 
 
@@ -44,5 +42,3 @@ def test_cfm_magnets(magnet_file, install_test_package):
     assert np.abs(o[1] - 3.39661431e-07) < 1e-10
     assert np.abs(o[2] + 1.59928207e-06) < 1e-10
     assert np.abs(o[3] + 1.74771216e-05) < 1e-10
-
-    Factory.clear()

--- a/tests/test_load_quad.py
+++ b/tests/test_load_quad.py
@@ -16,8 +16,6 @@ from pyaml.control.abstract_impl import (
 )
 from pyaml.magnet.cfm_magnet import CombinedFunctionMagnet
 from pyaml.magnet.hcorrector import HCorrector
-from pyaml.magnet.identity_model import IdentityMagnetModel
-from pyaml.magnet.quadrupole import ConfigModel as QuadrupoleConfigModel
 from pyaml.magnet.quadrupole import Quadrupole
 
 # TODO: Generate JSON pydantic schema for MetaConfigurator

--- a/tests/test_ranges_cfm_deviceaccess.py
+++ b/tests/test_ranges_cfm_deviceaccess.py
@@ -3,7 +3,6 @@ import pytest
 
 from pyaml import PyAMLException
 from pyaml.accelerator import Accelerator
-from pyaml.configuration.factory import Factory
 
 
 def _in_range(vmin, vmax) -> float:
@@ -21,7 +20,9 @@ def _out_of_range(vmin, vmax) -> float:
         return float(vmax) + 0.1
     if vmin is not None:
         return float(vmin) - 0.1
-    raise RuntimeError("Unbounded range [None, None], cannot build an out-of-range value.")
+    raise RuntimeError(
+        "Unbounded range [None, None], cannot build an out-of-range value."
+    )
 
 
 @pytest.mark.parametrize(
@@ -34,7 +35,9 @@ def _out_of_range(vmin, vmax) -> float:
     ],
     indirect=["install_test_package"],
 )
-def test_cfm_ranges_from_yaml_are_propagated_and_enforced(magnet_file, install_test_package):
+def test_cfm_ranges_from_yaml_are_propagated_and_enforced(
+    magnet_file, install_test_package
+):
     sr: Accelerator = Accelerator.load(magnet_file)
     sr.design.get_lattice().disable_6d()
 
@@ -55,11 +58,13 @@ def test_cfm_ranges_from_yaml_are_propagated_and_enforced(magnet_file, install_t
     assert got_ranges == expected_ranges
 
     # Build an in-range current vector (3 values)
-    in_currents = np.array([
-        _in_range(*expected_ranges[0]),
-        _in_range(*expected_ranges[1]),
-        _in_range(*expected_ranges[2]),
-    ])
+    in_currents = np.array(
+        [
+            _in_range(*expected_ranges[0]),
+            _in_range(*expected_ranges[1]),
+            _in_range(*expected_ranges[2]),
+        ]
+    )
 
     # Convert currents -> strengths (vector size 3)
     in_strengths = m.model.compute_strengths(in_currents)
@@ -73,5 +78,3 @@ def test_cfm_ranges_from_yaml_are_propagated_and_enforced(magnet_file, install_t
 
     with pytest.raises(PyAMLException, match="out of range"):
         m.strengths.set(out_strengths)
-
-    Factory.clear()

--- a/tests/test_rf.py
+++ b/tests/test_rf.py
@@ -3,7 +3,6 @@ import pytest
 
 from pyaml.accelerator import Accelerator
 from pyaml.common.exception import PyAMLException
-from pyaml.configuration.factory import Factory
 
 
 def test_rf():
@@ -32,8 +31,6 @@ def test_rf():
         RF.voltage.set(6.5e6)
         assert np.isclose(RF.frequency.get(), 3.523721693993786e8)
         assert np.isclose(RF.voltage.get(), 6.5e6)
-
-    Factory.clear()
 
 
 @pytest.mark.parametrize(
@@ -85,8 +82,6 @@ def test_rf_multi(install_test_package):
     assert np.isclose(RF2.voltage.get(), 2e6)
     assert np.isclose(RFTRA_HARMONIC.voltage.get(), 3e5)
 
-    Factory.clear()
-
 
 @pytest.mark.parametrize(
     "install_test_package",
@@ -116,5 +111,3 @@ def test_rf_multi_notrans(install_test_package):
 
     # Check that frequency and voltage has been applied on the masterclock device
     assert np.isclose(RF.frequency.get(), 3.523e8)
-
-    Factory.clear()

--- a/tests/test_serialized_magnets.py
+++ b/tests/test_serialized_magnets.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from pyaml.accelerator import Accelerator
-from pyaml.configuration.factory import Factory
 
 
 def check_no_diff(array: list[np.float64]) -> bool:
@@ -24,7 +23,9 @@ def check_no_diff(array: list[np.float64]) -> bool:
     ],
 )
 def test_config_load(sr_file):
-    sr: Accelerator = Accelerator.load(sr_file, use_fast_loader=True, ignore_external=True)
+    sr: Accelerator = Accelerator.load(
+        sr_file, use_fast_loader=True, ignore_external=True
+    )
     assert sr is not None
     magnets = [
         sr.design.get_element("QF8B-C04"),
@@ -46,4 +47,3 @@ def test_config_load(sr_file):
     currents = [magnet.hardware.get() for magnet in magnets]
     assert check_no_diff(strengths)
     assert check_no_diff(currents)
-    Factory.clear()

--- a/tests/test_tune.py
+++ b/tests/test_tune.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from pyaml.accelerator import Accelerator
-from pyaml.configuration.factory import Factory
 
 
 def test_tune():
@@ -51,5 +50,3 @@ def test_tune():
         strs = quadForTuneLive.strengths.get()
         strs += np.matmul(correctionmat, [0.1, 0.05])  # Ask for correction [dqx,dqy]
         quadForTuneLive.strengths.set(strs)
-
-    Factory.clear()

--- a/tests/test_tune_hardware.py
+++ b/tests/test_tune_hardware.py
@@ -2,11 +2,12 @@ import numpy as np
 import pytest
 
 from pyaml.accelerator import Accelerator
-from pyaml.configuration.factory import Factory
 
 
 def test_tune():
-    sr: Accelerator = Accelerator.load("tests/config/EBSTune.yaml", ignore_external=True)
+    sr: Accelerator = Accelerator.load(
+        "tests/config/EBSTune.yaml", ignore_external=True
+    )
     sr.design.get_lattice().disable_6d()
 
     quadForTuneDesign = sr.design.get_magnets("QForTune")
@@ -42,4 +43,3 @@ def test_tune():
     assert np.abs(currents[0] - 88.04522942) < 1e-8
     assert np.abs(currents[1] - 88.26677735) < 1e-8
     assert units[0] == "A" and units[1] == "A"
-    Factory.clear()

--- a/tests/test_tune_monitor.py
+++ b/tests/test_tune_monitor.py
@@ -1,17 +1,16 @@
 import pytest
 
 from pyaml.accelerator import Accelerator
-from pyaml.configuration.factory import Factory
 
 
 def test_simulator_tune_monitor():
-    sr: Accelerator = Accelerator.load("tests/config/tune_monitor.yaml", ignore_external=True)
+    sr: Accelerator = Accelerator.load(
+        "tests/config/tune_monitor.yaml", ignore_external=True
+    )
     sr.design.get_lattice().disable_6d()
     tune_monitor = sr.design.get_betatron_tune_monitor("BETATRON_TUNE")
     assert tune_monitor.tune.get()[0] == sr.design.get_lattice().get_tune()[0]
     assert tune_monitor.tune.get()[1] == sr.design.get_lattice().get_tune()[1]
-
-    Factory.clear()
 
 
 @pytest.mark.parametrize(
@@ -24,5 +23,3 @@ def test_controlsystem_tune_monitor(install_test_package):
     tune_monitor = sr.live.get_betatron_tune_monitor("BETATRON_TUNE")
     assert tune_monitor.tune.get()[0] == 0.0
     assert tune_monitor.tune.get()[1] == 0.0
-
-    Factory.clear()

--- a/tests/test_tuning_dispersion.py
+++ b/tests/test_tuning_dispersion.py
@@ -1,12 +1,7 @@
 import logging
 from pathlib import Path
 
-import numpy as np
-
 from pyaml.accelerator import Accelerator
-from pyaml.configuration.factory import Factory
-from pyaml.tuning_tools.dispersion import ConfigModel as Disp_ConfigModel
-from pyaml.tuning_tools.dispersion import Dispersion
 
 
 def test_tuning_orm():
@@ -26,5 +21,3 @@ def test_tuning_orm():
 
     assert len(dispersion_data["frequency_response_x"]) == len(bpms)
     assert len(dispersion_data["frequency_response_y"]) == len(bpms)
-
-    Factory.clear()

--- a/tests/test_tuning_orbit_correction.py
+++ b/tests/test_tuning_orbit_correction.py
@@ -4,9 +4,6 @@ from pathlib import Path
 import numpy as np
 
 from pyaml.accelerator import Accelerator
-from pyaml.configuration.factory import Factory
-from pyaml.tuning_tools.orbit import ConfigModel as Orbit_ConfigModel
-from pyaml.tuning_tools.orbit import Orbit
 
 
 def test_tuning_orm():
@@ -48,5 +45,3 @@ def test_tuning_orm():
     std_ac = np.std(positions_ac, axis=0)
     assert np.isclose(std_ac[0], 5.041856471193712e-07, rtol=0, atol=1e-14)
     assert np.isclose(std_ac[1], 4.789269566479167e-07, rtol=0, atol=1e-14)
-
-    Factory.clear()

--- a/tests/test_tuning_orm.py
+++ b/tests/test_tuning_orm.py
@@ -4,9 +4,6 @@ from pathlib import Path
 import numpy as np
 
 from pyaml.accelerator import Accelerator
-from pyaml.configuration.factory import Factory
-from pyaml.tuning_tools.orbit_response_matrix import ConfigModel as ORM_ConfigModel
-from pyaml.tuning_tools.orbit_response_matrix import OrbitResponseMatrix
 
 
 def test_tuning_orm():
@@ -27,5 +24,3 @@ def test_tuning_orm():
     orm_data = orm.get()
     orm_shape = np.array(orm_data["matrix"]).shape
     assert orm_shape == (2 * len(bpms), 8)
-
-    Factory.clear()

--- a/tests/test_tuning_tools.py
+++ b/tests/test_tuning_tools.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from pyaml.accelerator import Accelerator
 from pyaml.common.constants import ACTION_RESTORE
-from pyaml.configuration.factory import Factory
 from pyaml.magnet.magnet import Magnet
 
 
@@ -23,5 +22,3 @@ def test_tuning_tools():
     tune = sr.design.tune.readback()
     assert np.abs(tune[0] - 0.17) < 1e-5
     assert np.abs(tune[1] - 0.32) < 1e-5
-
-    Factory.clear()


### PR DESCRIPTION
This PR fixes [#139](https://github.com/python-accelerator-middle-layer/pyaml/issues/139)
Removed unused Factory.clear() in tests