### PR TITLE
Removed CS deps from doc build process

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -46,9 +46,6 @@ jobs:
 
       - name: Install package
         run: |
-          python -m pip install tango-pyaml
-          python -m pip install pyaml-cs-oa[tango]
-          python -m pip install pyaml-cs-oa[epics]
           python -m pip install '.[doc]'
 
       - name: Build documentation


### PR DESCRIPTION
This PR remove deps for documentation build process in order to fix [#197](https://github.com/python-accelerator-middle-layer/pyaml/issues/197)