### PR TITLE
Added tune step method (no tune monitor)

### DIFF
--- a/pyaml/tuning_tools/tune.py
+++ b/pyaml/tuning_tools/tune.py
@@ -212,15 +212,28 @@ class Tune(Element):
         wait_time : float
             Time to wait in second between 2 iterations
         """
-        self.__setpoint = np.array(tune)
         for i in range(iter):
             diff_tune = tune - self.readback()
-            str = self.__tr.quads().strengths.get()
-            str += self.__tr.correct(diff_tune)
-            self.__tr.quads().strengths.set(str)
-            if i < iter - 1:
-                # Does not wait on the last iter
-                time.sleep(wait_time)
+            if i == iter:
+                wait_time = 0  # do not wait on last iteration
+            self.step(diff_tune, wait_time)
+        self.__setpoint = np.array(tune)
+
+    def step(self, dtune: np.array, wait_time: float = 0.0):
+        """
+        Step the tune by a delta
+        Parameters
+        ----------
+        dtune : np.array
+            Delta tune
+        iter_nb: int
+        wait_time: float
+        """
+        strengths = self.__tr.quads().strengths.get()
+        strengths += self.__tr.correct(dtune)
+        self.__tr.quads().strengths.set(strengths)
+        time.sleep(wait_time)
+        self.__setpoint += dtune
 
     @property
     def response(self) -> TuneResponse:

--- a/tests/test_tuning_tools.py
+++ b/tests/test_tuning_tools.py
@@ -22,3 +22,14 @@ def test_tuning_tools():
     tune = sr.design.tune.readback()
     assert np.abs(tune[0] - 0.17) < 1e-5
     assert np.abs(tune[1] - 0.32) < 1e-5
+
+
+def test_tune_step():
+    sr = Accelerator.load("tests/config/EBSTune.yaml", use_fast_loader=False)
+    sr.design.get_lattice().disable_6d()
+    sr.design.tune.response.measure(callback=tune_callback)
+    tune_initial = sr.design.tune.readback()
+    dtune = np.array([0.01, -0.01])
+    sr.design.tune.step(dtune)
+    tune = sr.design.tune.readback()
+    np.testing.assert_allclose(tune - tune_initial, dtune, atol=1e-5)


### PR DESCRIPTION
Added tune step method that will change the tune and its setpoint without looking at BetatronTuneMonitor. tune.set() is now using tune.step() under the hood.

Resolves #138 .