### PR TITLE
Change to using automatic versioning from Git tags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,16 +28,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy
-        pip install scipy
-        pip install pydantic
-        pip install accelerator-toolbox
-        pip install accelerator-commissioning==1.1.0
-        pip install matplotlib
-        pip install h5py
-        pip install PyYaml
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install .[test]
+        pip install flake8
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,21 +28,10 @@ If manual intervention is required, please follow the instructions provided by t
 #### Releasing a new version on PyPi
 
 1. Create a branch for a release
-2. Set the version in pyaml/__init__.py:
-
-```
-__title__ = "pyAML"
-__description__ = "Python Accelerator Middle Layer"
-__url__ = "https://github.com/python-accelerator-middle-layer/pyaml"
-__version__ = "0.2.4"
-__author__ = "pyAML collaboration"
-__author_email__ = ""
-```
-3. Provide a list of changes and release description in the merge request. Justify a version bump is necessary.
-4. Approve and merge the PR
-
-5. Then tag to the corresponding version.
-6. CI/CD will take care of PyPi release. (Make sure the version in CI/CD deployment pipeline matches the one you just tagged.)
+2. Provide a list of changes and release description in the merge request. Justify a version bump is necessary.
+3. Tag the corresponding version.
+4. Approve and merge the PR.
+5. CI/CD will take care of PyPi release. (Make sure the version in CI/CD deployment pipeline matches the one you just tagged.)
 ### 4. Documentation
 - **Improving Docs:** Fix typos, clarify instructions, or add missing documentation. Submit a PR as you would for code changes.
 - **Website:** Our project website is at [python-accelerator-middle-layer.github.io](https://python-accelerator-middle-layer.github.io/).

--- a/pyaml/__init__.py
+++ b/pyaml/__init__.py
@@ -5,6 +5,8 @@ pyAML package
 pyAML
 """
 
+from ._version import __version__
+
 __title__ = "pyAML"
 __description__ = "Python Accelerator Middle Layer"
 __url__ = "https://github.com/python-accelerator-middle-layer/pyaml"

--- a/pyaml/__init__.py
+++ b/pyaml/__init__.py
@@ -8,7 +8,6 @@ pyAML
 __title__ = "pyAML"
 __description__ = "Python Accelerator Middle Layer"
 __url__ = "https://github.com/python-accelerator-middle-layer/pyaml"
-__version__ = "0.2.3"
 __author__ = "pyAML collaboration"
 __author_email__ = ""
 
@@ -17,7 +16,7 @@ import os
 
 from pyaml.common.exception import PyAMLConfigException, PyAMLException
 
-__all__ = [__version__, "PyAMLException", "PyAMLConfigException"]
+__all__ = ["PyAMLException", "PyAMLConfigException"]
 
 
 config_file = os.getenv("PYAML_LOG_CONFIG", "pyaml_logging.conf")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,23 +1,3 @@
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.version]
-path = "pyaml/__init__.py"
-
-[tool.hatch.build.targets.sdist]
-exclude = [
-  "/.github",
-  "/docs",
-  "/tests",
-]
-
-[tool.hatch.build.targets.wheel]
-packages = ["pyaml"]
-
-[tool.hatch.metadata]
-allow-direct-references = true
-
 [project]
 name = "accelerator-middle-layer"
 description = "Python Accelerator Middle Layer"
@@ -90,6 +70,26 @@ dev = [
 Homepage = "https://github.com/python-accelerator-middle-layer/pyaml"
 Documentation = "https://python-accelerator-middle-layer.github.io/pyaml/"
 Repository = "https://github.com/python-accelerator-middle-layer/pyaml.git"
+
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.github",
+  "/docs",
+  "/tests",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["pyaml"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ packages = ["pyaml"]
 [tool.hatch.metadata]
 allow-direct-references = true
 
+[tool.hatch.build.hooks.vcs]
+version-file = "pyaml/_version.py"
+
 [tool.ruff]
 line-length = 88
 target-version = "py311"


### PR DESCRIPTION
I have added automatic versioning from Git tags in the pyproject.toml. Advantages of this:

- There is no hardcoded version number that needs to be manually bumped when making a new release. Instead the release can be built based on a Git tag which simplifies the release workflow.

- If you install directly from the Git repository you will get a version number based on the next release number + the commit number making it easier to distinguish between the developer version and the released version. This helps to know which version you have installed when debugging. For example it might look like this in `pip list`:

```
accelerator-middle-layer  0.2.4.dev166+g983a827d1.d20260309
```