### PR TITLE
228 feature allow incremental accelerator configuration with config manager

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
+        pip install ./tests/dummy_cs/tango-pyaml
+        pip install ./tests/external
         pip install flake8
     - name: Lint with flake8
       run: |

--- a/pyaml/accelerator.py
+++ b/pyaml/accelerator.py
@@ -10,6 +10,7 @@ from .arrays.array import ArrayConfig
 from .common.element import Element
 from .common.element_holder import ElementHolder
 from .common.exception import PyAMLConfigException
+from .configuration import ConfigurationManager, UnsupportedConfigurationRootError
 from .configuration.factory import Factory
 from .configuration.fileloader import load, set_root_folder
 from .control.controlsystem import ControlSystem
@@ -249,11 +250,15 @@ class Accelerator(object):
             cannot be created. pydantic schema that support that an
             object is not created should handle None fields.
         """
-        # Asume that all files are referenced from
-        # folder where main AML file is stored
         if not os.path.exists(filename):
             raise PyAMLConfigException(f"{filename} file not found")
-        rootfolder = os.path.abspath(os.path.dirname(filename))
-        set_root_folder(rootfolder)
-        config_dict = load(os.path.basename(filename), None, use_fast_loader)
-        return Accelerator.from_dict(config_dict, ignore_external=ignore_external)
+
+        manager = ConfigurationManager()
+        try:
+            manager.add(filename, use_fast_loader=use_fast_loader)
+            return manager.build(ignore_external=ignore_external)
+        except UnsupportedConfigurationRootError:
+            rootfolder = os.path.abspath(os.path.dirname(filename))
+            set_root_folder(rootfolder)
+            config_dict = load(os.path.basename(filename), None, use_fast_loader)
+            return Accelerator.from_dict(config_dict, ignore_external=ignore_external)

--- a/pyaml/accelerator.py
+++ b/pyaml/accelerator.py
@@ -2,8 +2,6 @@
 Accelerator class
 """
 
-import os
-
 from pydantic import BaseModel, ConfigDict, Field
 
 from .arrays.array import ArrayConfig
@@ -249,9 +247,6 @@ class Accelerator(object):
             cannot be created. pydantic schema that support that an
             object is not created should handle None fields.
         """
-        if not os.path.exists(filename):
-            raise PyAMLConfigException(f"{filename} file not found")
-
         manager = ConfigurationManager()
         try:
             manager.add(filename, use_fast_loader=use_fast_loader)

--- a/pyaml/accelerator.py
+++ b/pyaml/accelerator.py
@@ -12,7 +12,6 @@ from .common.element_holder import ElementHolder
 from .common.exception import PyAMLConfigException
 from .configuration import ConfigurationManager, UnsupportedConfigurationRootError
 from .configuration.factory import Factory
-from .configuration.fileloader import load, set_root_folder
 from .control.controlsystem import ControlSystem
 from .lattice.simulator import Simulator
 from .yellow_pages import YellowPages
@@ -256,9 +255,9 @@ class Accelerator(object):
         manager = ConfigurationManager()
         try:
             manager.add(filename, use_fast_loader=use_fast_loader)
-            return manager.build(ignore_external=ignore_external)
-        except UnsupportedConfigurationRootError:
-            rootfolder = os.path.abspath(os.path.dirname(filename))
-            set_root_folder(rootfolder)
-            config_dict = load(os.path.basename(filename), None, use_fast_loader)
-            return Accelerator.from_dict(config_dict, ignore_external=ignore_external)
+        except UnsupportedConfigurationRootError as ex:
+            raise PyAMLConfigException(
+                "Accelerator.load() expects a 'pyaml.accelerator' root configuration. "
+                "Use the factory APIs to build sub-elements directly."
+            ) from ex
+        return manager.build(ignore_external=ignore_external)

--- a/pyaml/apidoc/gen_api.py
+++ b/pyaml/apidoc/gen_api.py
@@ -38,6 +38,7 @@ modules = [
     "pyaml.configuration.fileloader",
     "pyaml.configuration.inline_curve",
     "pyaml.configuration.inline_matrix",
+    "pyaml.configuration.manager",
     "pyaml.configuration.matrix",
     "pyaml.control.abstract_impl",
     "pyaml.control.controlsystem",
@@ -125,7 +126,7 @@ def generate_selective_module(m):
             if m in ["pyaml.arrays.element_array"]:
                 # Include special members for operator overloading
                 file.write("         :special-members: __add__, __and__, __or__, __sub__ \n")
-            if m in ["pyaml.yellow_pages"]:
+            if m in ["pyaml.yellow_pages", "pyaml.configuration.manager"]:
                 # Include special members for exploratory overloading
                 file.write("         :special-members: __dir__, __getattr__, __getitem__, __repr__, __str__ \n")
             file.write("         :exclude-members: model_config\n")

--- a/pyaml/configuration/__init__.py
+++ b/pyaml/configuration/__init__.py
@@ -4,3 +4,12 @@ PyAML configuration module
 
 from .factory import Factory
 from .fileloader import get_root_folder, set_root_folder
+from .manager import ConfigurationManager, UnsupportedConfigurationRootError
+
+__all__ = [
+    "ConfigurationManager",
+    "UnsupportedConfigurationRootError",
+    "Factory",
+    "get_root_folder",
+    "set_root_folder",
+]

--- a/pyaml/configuration/manager.py
+++ b/pyaml/configuration/manager.py
@@ -1,0 +1,480 @@
+import copy
+import fnmatch
+import os
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from ..common.exception import PyAMLConfigException
+from .fileloader import get_root_folder, load, set_root_folder
+
+_INTERNAL_METADATA_KEYS = {"__location__", "__fieldlocations__"}
+_VALID_QUERY_KEY_RE = re.compile(r"^[A-Z0-9_]+$")
+_CATEGORY_TITLES = {
+    "controls": "Controls",
+    "simulators": "Simulators",
+    "arrays": "Arrays",
+    "devices": "Devices",
+}
+
+
+class UnsupportedConfigurationRootError(PyAMLConfigException):
+    """Raised when a fragment root is outside ConfigurationManager scope."""
+
+
+class ConfigurationManager:
+    """
+    Aggregate accelerator configuration fragments before runtime build.
+    """
+
+    DEFAULT_TYPE = "pyaml.accelerator"
+    ROOT_FIELDS = (
+        "type",
+        "facility",
+        "machine",
+        "energy",
+        "alphac",
+        "data_folder",
+        "description",
+    )
+    NAMED_CATEGORIES = ("controls", "simulators", "arrays", "devices")
+    _SUPPORTED_FILE_SUFFIXES = {".yaml", ".yml", ".json"}
+
+    def __init__(self):
+        self._state: dict[str, Any] = {"type": self.DEFAULT_TYPE}
+        self._items_by_category: dict[str, dict[str, dict[str, Any]]] = {
+            category: {} for category in self.NAMED_CATEGORIES
+        }
+        self._sources_by_category: dict[str, dict[str, str]] = {category: {} for category in self.NAMED_CATEGORIES}
+        self._field_sources: dict[str, str] = {}
+        self._build_root: Path = get_root_folder()
+        self._build_root_locked = False
+
+    def add(self, payload, **kwargs) -> "ConfigurationManager":
+        """
+        Add a configuration fragment from a dict or a YAML/JSON file.
+        """
+        source_name = kwargs.pop("source_name", None)
+        use_fast_loader = kwargs.pop("use_fast_loader", False)
+        if kwargs:
+            unknown = ", ".join(sorted(kwargs))
+            raise PyAMLConfigException(f"Unsupported ConfigurationManager.add() arguments: {unknown}")
+
+        fragment, inferred_source_name, source_root = self._load_payload(
+            payload,
+            source_name=source_name,
+            use_fast_loader=use_fast_loader,
+        )
+        prepared = self._prepare_fragment(fragment, source_root, inferred_source_name)
+        self._merge_fragment(prepared, inferred_source_name)
+        return self
+
+    def remove(self, category: str, name: str) -> "ConfigurationManager":
+        """
+        Remove a named entry from an aggregated category.
+        """
+        self._require_named_category(category)
+        if name not in self._items_by_category[category]:
+            raise PyAMLConfigException(f"Configuration entry '{name}' not found in category '{category}'.")
+
+        self._state[category] = [entry for entry in self._state.get(category, []) if entry.get("name") != name]
+        self._items_by_category[category].pop(name, None)
+        self._sources_by_category[category].pop(name, None)
+        return self
+
+    def replace(self, category: str, element: dict) -> "ConfigurationManager":
+        """
+        Replace an existing named entry in an aggregated category.
+        """
+        self._require_named_category(category)
+        prepared = self._prepare_fragment(
+            {category: [copy.deepcopy(element)]},
+            self._build_root,
+            f"replace:{category}",
+        )
+        replacement = prepared[category][0]
+        name = replacement["name"]
+
+        if name not in self._items_by_category[category]:
+            raise PyAMLConfigException(
+                f"Configuration entry '{name}' not found in category '{category}'. Use add() to create it."
+            )
+
+        entries = self._state.get(category, [])
+        for index, entry in enumerate(entries):
+            if entry.get("name") == name:
+                entries[index] = replacement
+                break
+
+        self._items_by_category[category][name] = replacement
+        self._sources_by_category[category][name] = "replace()"
+        return self
+
+    def clear(self, category: str | None = None) -> "ConfigurationManager":
+        """
+        Clear the aggregated state, or a single root field/category.
+        """
+        if category is None:
+            self._state = {"type": self.DEFAULT_TYPE}
+            self._field_sources.clear()
+            for name in self.NAMED_CATEGORIES:
+                self._items_by_category[name].clear()
+                self._sources_by_category[name].clear()
+            self._build_root = get_root_folder()
+            self._build_root_locked = False
+            return self
+
+        if category in self.NAMED_CATEGORIES:
+            self._state[category] = []
+            self._items_by_category[category].clear()
+            self._sources_by_category[category].clear()
+            return self
+
+        if category == "type":
+            self._state["type"] = self.DEFAULT_TYPE
+            self._field_sources.pop("type", None)
+            return self
+
+        if category in self._state:
+            self._state.pop(category, None)
+            self._field_sources.pop(category, None)
+            return self
+
+        raise PyAMLConfigException(f"Unknown configuration category '{category}'.")
+
+    def categories(self) -> list[str]:
+        return [
+            category
+            for category in self.NAMED_CATEGORIES
+            if self._state.get(category) and len(self._state[category]) > 0
+        ]
+
+    def keys(self, category: str | None = None) -> list[str]:
+        if category is None:
+            names: list[str] = []
+            for current_category in self.NAMED_CATEGORIES:
+                self._extend_unique(names, self._items_by_category[current_category].keys())
+            return names
+
+        self._require_named_category(category)
+        return list(self._items_by_category[category].keys())
+
+    def has(self, category: str, name: str) -> bool:
+        self._require_named_category(category)
+        return name in self._items_by_category[category]
+
+    def get(self, category: str, name: str) -> dict[str, Any]:
+        self._require_named_category(category)
+        if name not in self._items_by_category[category]:
+            raise KeyError(f"Configuration entry '{name}' not found in category '{category}'.")
+        return self._strip_internal_metadata(copy.deepcopy(self._items_by_category[category][name]))
+
+    def find(self, pattern: str, category: str | None = None) -> list[str]:
+        if not pattern or not pattern.strip():
+            raise PyAMLConfigException("Empty configuration query.")
+
+        names = self.keys(category)
+        pattern = pattern.strip()
+        if pattern.startswith("re:"):
+            regex_source = pattern[3:]
+            try:
+                regex = re.compile(regex_source)
+            except re.error as exc:
+                raise PyAMLConfigException(f"Invalid regex '{regex_source}': {exc}") from exc
+            return [name for name in names if regex.search(name)]
+
+        return [name for name in names if fnmatch.fnmatch(name, pattern)]
+
+    def settings(self) -> dict[str, Any]:
+        settings: dict[str, Any] = {}
+        ordered_fields = [field for field in self.ROOT_FIELDS if field in self._state]
+        extra_fields = [
+            field
+            for field in self._state.keys()
+            if field not in self.NAMED_CATEGORIES
+            and field not in ordered_fields
+            and field not in _INTERNAL_METADATA_KEYS
+        ]
+        for field in ordered_fields + extra_fields:
+            settings[field] = copy.deepcopy(self._state[field])
+        return self._strip_internal_metadata(settings)
+
+    def to_dict(self) -> dict[str, Any]:
+        snapshot = self._snapshot(include_internal_metadata=False)
+        return snapshot
+
+    def build(self, ignore_external: bool = False):
+        """
+        Build an Accelerator from the aggregated configuration snapshot.
+        """
+        from ..accelerator import Accelerator
+
+        set_root_folder(self._build_root)
+        return Accelerator.from_dict(self._snapshot(include_internal_metadata=True), ignore_external=ignore_external)
+
+    def __dir__(self):
+        default = super().__dir__()
+        valid_keys = {key for key in self.keys() if _VALID_QUERY_KEY_RE.match(key)}
+        return sorted(set(default) | valid_keys)
+
+    def __getitem__(self, query: str) -> list[str]:
+        """
+        Alias for :meth:`find`.
+        """
+        return self.find(query)
+
+    def __getattr__(self, name):
+        if name in self._items_by_category:
+            return self.keys(name)
+        categories = self._categories_for_name(name)
+        if len(categories) == 1:
+            return self.get(categories[0], name)
+        if len(categories) > 1:
+            raise AttributeError(
+                f"ConfigurationManager key '{name}' is ambiguous across categories {categories}. "
+                "Use get(category, name)."
+            )
+        raise AttributeError(f"'ConfigurationManager' object has no attribute '{name}'")
+
+    def __repr__(self) -> str:
+        lines: list[str] = []
+
+        settings = self.settings()
+        lines.append("Settings:")
+        if settings:
+            for key, value in settings.items():
+                lines.append(f"    {key}: {value}")
+        lines.append("    .")
+        lines.append("")
+
+        for category in self.NAMED_CATEGORIES:
+            lines.append(f"{_CATEGORY_TITLES[category]}:")
+            entries = self._items_by_category[category]
+            if entries:
+                for entry in self._state.get(category, []):
+                    lines.append(self._format_entry(category, entry))
+            lines.append("    .")
+            lines.append("")
+
+        return "\n".join(lines).rstrip()
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def _load_payload(
+        self,
+        payload,
+        *,
+        source_name: str | None,
+        use_fast_loader: bool,
+    ) -> tuple[dict[str, Any], str, Path | None]:
+        if isinstance(payload, dict):
+            return copy.deepcopy(payload), source_name or "<dict>", None
+
+        payload_path = self._coerce_path(payload)
+        parsed = urlparse(payload_path)
+        if parsed.scheme in {"http", "https"}:
+            raise PyAMLConfigException(f"REST configuration sources are not implemented yet for '{payload_path}'.")
+
+        path = Path(payload_path)
+        suffix = path.suffix.lower()
+        if suffix not in self._SUPPORTED_FILE_SUFFIXES:
+            raise PyAMLConfigException(
+                f"Cannot infer configuration source from '{payload_path}'. "
+                "Supported inputs are dict, .yaml/.yml files or .json files."
+            )
+
+        if not path.exists():
+            raise PyAMLConfigException(f"{payload_path} file not found")
+
+        resolved_path = path.resolve()
+        previous_root = get_root_folder()
+        source_root = resolved_path.parent
+        try:
+            set_root_folder(source_root)
+            fragment = load(resolved_path.name, None, use_fast_loader)
+        finally:
+            set_root_folder(previous_root)
+
+        if not self._build_root_locked:
+            self._build_root = source_root
+            self._build_root_locked = True
+
+        return fragment, source_name or str(resolved_path), source_root
+
+    def _prepare_fragment(
+        self,
+        fragment: dict[str, Any],
+        source_root: Path | None,
+        source_name: str,
+    ) -> dict[str, Any]:
+        if not isinstance(fragment, dict):
+            raise PyAMLConfigException(
+                f"ConfigurationManager.add() expects a mapping at the top level, got '{type(fragment).__name__}'."
+            )
+
+        accelerator_type = fragment.get("type", self.DEFAULT_TYPE)
+        if accelerator_type != self.DEFAULT_TYPE:
+            raise UnsupportedConfigurationRootError(
+                f"ConfigurationManager only supports '{self.DEFAULT_TYPE}' roots, got '{accelerator_type}'."
+            )
+
+        prepared = copy.deepcopy(fragment)
+        prepared["type"] = self.DEFAULT_TYPE
+
+        for category in self.NAMED_CATEGORIES:
+            if category not in prepared:
+                continue
+
+            entries = prepared[category]
+            if not isinstance(entries, list):
+                raise PyAMLConfigException(f"Configuration category '{category}' must be a list.")
+
+            for index, entry in enumerate(entries):
+                if not isinstance(entry, dict):
+                    raise PyAMLConfigException(
+                        f"Configuration category '{category}' expects object entries, "
+                        f"found '{type(entry).__name__}' at index {index} from source '{source_name}'."
+                    )
+                if "name" not in entry:
+                    raise PyAMLConfigException(
+                        f"Configuration category '{category}' expects named objects, "
+                        f"but entry at index {index} from source '{source_name}' has no 'name'."
+                    )
+                if "type" not in entry:
+                    raise PyAMLConfigException(
+                        f"Configuration entry '{entry['name']}' in category '{category}' has no 'type'."
+                    )
+
+                if category == "simulators":
+                    self._normalize_simulator_paths(entry, source_root)
+
+        return prepared
+
+    def _merge_fragment(self, fragment: dict[str, Any], source_name: str) -> None:
+        duplicate_errors: list[str] = []
+        pending_by_category: dict[str, list[dict[str, Any]]] = {}
+
+        for category in self.NAMED_CATEGORIES:
+            if category not in fragment:
+                continue
+
+            entries = fragment[category]
+            seen_in_fragment: set[str] = set()
+            for entry in entries:
+                name = entry["name"]
+                if name in seen_in_fragment:
+                    duplicate_errors.append(
+                        f"Configuration entry '{name}' is duplicated inside category '{category}' in source "
+                        f"'{source_name}'."
+                    )
+                    continue
+                if name in self._items_by_category[category]:
+                    previous_source = self._sources_by_category[category].get(name, "<unknown>")
+                    duplicate_errors.append(
+                        f"Configuration entry '{name}' already exists in category '{category}' "
+                        f"(from '{previous_source}'). Use replace() to override it."
+                    )
+                    continue
+                seen_in_fragment.add(name)
+
+            pending_by_category[category] = entries
+
+        if duplicate_errors:
+            raise PyAMLConfigException(duplicate_errors[0])
+
+        for field, value in fragment.items():
+            if field in self.NAMED_CATEGORIES:
+                continue
+            self._state[field] = copy.deepcopy(value)
+            if field not in _INTERNAL_METADATA_KEYS:
+                self._field_sources[field] = source_name
+
+        for category, entries in pending_by_category.items():
+            target = self._state.setdefault(category, [])
+            for entry in entries:
+                copied = copy.deepcopy(entry)
+                target.append(copied)
+                self._items_by_category[category][copied["name"]] = copied
+                self._sources_by_category[category][copied["name"]] = source_name
+
+    def _snapshot(self, *, include_internal_metadata: bool) -> dict[str, Any]:
+        snapshot = copy.deepcopy(self._state)
+        if include_internal_metadata:
+            return snapshot
+        return self._strip_internal_metadata(snapshot)
+
+    def _normalize_simulator_paths(self, entry: dict[str, Any], source_root: Path | None) -> None:
+        if source_root is None:
+            return
+
+        lattice = entry.get("lattice")
+        if isinstance(lattice, str) and not os.path.isabs(lattice):
+            entry["lattice"] = str((source_root / lattice).resolve())
+
+    def _require_named_category(self, category: str) -> None:
+        if category not in self.NAMED_CATEGORIES:
+            raise PyAMLConfigException(
+                f"Unknown configuration category '{category}'. Expected one of: {', '.join(self.NAMED_CATEGORIES)}."
+            )
+
+    def _categories_for_name(self, name: str) -> list[str]:
+        categories: list[str] = []
+        for category in self.NAMED_CATEGORIES:
+            if name in self._items_by_category[category]:
+                categories.append(category)
+        return categories
+
+    def _format_entry(self, category: str, entry: dict[str, Any]) -> str:
+        name = entry.get("name", "<unnamed>")
+        entry_type = entry.get("type")
+        type_part = f" ({entry_type})" if entry_type else ""
+
+        details: list[str] = []
+        if category == "arrays":
+            selectors = entry.get("elements")
+            if isinstance(selectors, list):
+                details.append(f"selectors={len(selectors)}")
+
+        source = self._sources_by_category[category].get(name)
+        if source is not None:
+            details.append(f"source={self._format_source(source)}")
+
+        detail_part = ""
+        if details:
+            detail_part = " " + " ".join(details)
+
+        return f"    {name}{type_part}{detail_part}"
+
+    def _format_source(self, source: str) -> str:
+        if source.startswith("<") and source.endswith(">"):
+            return source
+        source_path = Path(source)
+        suffix = source_path.suffix.lower()
+        if suffix in self._SUPPORTED_FILE_SUFFIXES:
+            return source_path.name
+        return source
+
+    def _coerce_path(self, payload) -> str:
+        if isinstance(payload, (str, os.PathLike)):
+            return os.fspath(payload)
+        raise PyAMLConfigException(
+            f"Cannot infer configuration source from payload of type '{type(payload).__name__}'."
+        )
+
+    def _extend_unique(self, target: list[str], values) -> None:
+        for value in values:
+            if value not in target:
+                target.append(value)
+
+    def _strip_internal_metadata(self, value):
+        if isinstance(value, list):
+            return [self._strip_internal_metadata(entry) for entry in value]
+        if isinstance(value, dict):
+            return {
+                key: self._strip_internal_metadata(entry)
+                for key, entry in value.items()
+                if key not in _INTERNAL_METADATA_KEYS
+            }
+        return value

--- a/pyaml/configuration/manager.py
+++ b/pyaml/configuration/manager.py
@@ -1,3 +1,18 @@
+"""
+manager.py
+
+Configuration aggregation helpers for :class:`~pyaml.accelerator.Accelerator`.
+
+This module provides :class:`ConfigurationManager`, a lightweight service used
+to collect configuration fragments before runtime objects are built.
+
+Typical usage is:
+
+- load one or more accelerator configuration fragments
+- inspect or query the aggregated state
+- build the final :class:`~pyaml.accelerator.Accelerator`
+"""
+
 import copy
 import fnmatch
 import os
@@ -24,22 +39,70 @@ class UnsupportedConfigurationRootError(PyAMLConfigException):
 
 
 class ConfigurationManager:
-    """
+    r"""
     Aggregate accelerator configuration fragments before runtime build.
+
+    :class:`ConfigurationManager` stores configuration fragments as plain
+    dictionaries and exposes convenience helpers to inspect, query and update
+    them before constructing the final runtime object graph.
+
+    Notes
+    -----
+    The manager only accepts accelerator-root fragments and merges named
+    categories such as ``controls``, ``simulators``, ``arrays`` and
+    ``devices``.
+
+    Examples
+    --------
+
+    Load a base configuration and inspect it:
+
+    .. code-block:: python
+
+        >>> from pyaml.configuration import ConfigurationManager
+        >>> manager = ConfigurationManager()
+        >>> manager.add("tests/config/config_manager_base.yaml")
+        >>> manager.categories()
+        ['simulators']
+
+    Build the final accelerator:
+
+    .. code-block:: python
+
+        >>> sr = manager.build()
+        >>> sr.design.name()
+        'design'
     """
 
     DEFAULT_TYPE = "pyaml.accelerator"
-    ROOT_FIELDS = (
-        "type",
-        "facility",
-        "machine",
-        "energy",
-        "alphac",
-        "data_folder",
-        "description",
-    )
     NAMED_CATEGORIES = ("controls", "simulators", "arrays", "devices")
     _SUPPORTED_FILE_SUFFIXES = {".yaml", ".yml", ".json"}
+
+    @classmethod
+    def root_fields(cls) -> tuple[str, ...]:
+        r"""
+        Return the ordered root fields supported by the accelerator model.
+
+        The field order is derived from
+        :class:`~pyaml.accelerator.ConfigModel`.
+
+        Returns
+        -------
+        tuple[str, ...]
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> ConfigurationManager.root_fields()
+        """
+        from ..accelerator import ConfigModel as AcceleratorConfigModel
+
+        config_fields = tuple(
+            field_name for field_name in AcceleratorConfigModel.model_fields if field_name not in cls.NAMED_CATEGORIES
+        )
+        return ("type", *config_fields)
 
     def __init__(self):
         self._state: dict[str, Any] = {"type": self.DEFAULT_TYPE}
@@ -51,9 +114,37 @@ class ConfigurationManager:
         self._build_root: Path = get_root_folder()
         self._build_root_locked = False
 
-    def add(self, payload, **kwargs) -> "ConfigurationManager":
-        """
+    def add(self, payload, **kwargs) -> None:
+        r"""
         Add a configuration fragment from a dict or a YAML/JSON file.
+
+        Parameters
+        ----------
+        payload : dict or str or os.PathLike
+            Fragment to merge into the current aggregated state.
+        source_name : str, optional
+            Explicit source label to associate with the fragment.
+        use_fast_loader : bool, optional
+            Forwarded to the configuration loader.
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> manager.add("tests/config/config_manager_base.yaml")
+
+        .. code-block:: python
+
+            >>> manager.add(
+            ...     {
+            ...         "facility": "ESRF",
+            ...         "machine": "sr",
+            ...         "energy": 6e9,
+            ...         "data_folder": "/data/store",
+            ...         "devices": [],
+            ...     }
+            ... )
         """
         source_name = kwargs.pop("source_name", None)
         use_fast_loader = kwargs.pop("use_fast_loader", False)
@@ -68,11 +159,24 @@ class ConfigurationManager:
         )
         prepared = self._prepare_fragment(fragment, source_root, inferred_source_name)
         self._merge_fragment(prepared, inferred_source_name)
-        return self
 
-    def remove(self, category: str, name: str) -> "ConfigurationManager":
-        """
+    def remove(self, category: str, name: str) -> None:
+        r"""
         Remove a named entry from an aggregated category.
+
+        Parameters
+        ----------
+        category : str
+            Category that contains the entry.
+        name : str
+            Entry name to remove.
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> manager.remove("simulators", "tracking")
         """
         self._require_named_category(category)
         if name not in self._items_by_category[category]:
@@ -81,11 +185,31 @@ class ConfigurationManager:
         self._state[category] = [entry for entry in self._state.get(category, []) if entry.get("name") != name]
         self._items_by_category[category].pop(name, None)
         self._sources_by_category[category].pop(name, None)
-        return self
 
-    def replace(self, category: str, element: dict) -> "ConfigurationManager":
-        """
+    def replace(self, category: str, element: dict) -> None:
+        r"""
         Replace an existing named entry in an aggregated category.
+
+        Parameters
+        ----------
+        category : str
+            Category that contains the entry.
+        element : dict
+            Replacement configuration entry.
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> manager.replace(
+            ...     "simulators",
+            ...     {
+            ...         "type": "pyaml.lattice.simulator",
+            ...         "name": "design",
+            ...         "lattice": "tests/config/sr/lattices/ebs.mat",
+            ...     },
+            ... )
         """
         self._require_named_category(category)
         prepared = self._prepare_fragment(
@@ -109,11 +233,26 @@ class ConfigurationManager:
 
         self._items_by_category[category][name] = replacement
         self._sources_by_category[category][name] = "replace()"
-        return self
 
-    def clear(self, category: str | None = None) -> "ConfigurationManager":
-        """
+    def clear(self, category: str | None = None) -> None:
+        r"""
         Clear the aggregated state, or a single root field/category.
+
+        Parameters
+        ----------
+        category : str, optional
+            If provided, only that category or root field is cleared.
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> manager.clear("simulators")
+
+        .. code-block:: python
+
+            >>> manager.clear()
         """
         if category is None:
             self._state = {"type": self.DEFAULT_TYPE}
@@ -123,27 +262,41 @@ class ConfigurationManager:
                 self._sources_by_category[name].clear()
             self._build_root = get_root_folder()
             self._build_root_locked = False
-            return self
+            return
 
         if category in self.NAMED_CATEGORIES:
             self._state[category] = []
             self._items_by_category[category].clear()
             self._sources_by_category[category].clear()
-            return self
+            return
 
         if category == "type":
             self._state["type"] = self.DEFAULT_TYPE
             self._field_sources.pop("type", None)
-            return self
+            return
 
         if category in self._state:
             self._state.pop(category, None)
             self._field_sources.pop(category, None)
-            return self
+            return
 
         raise PyAMLConfigException(f"Unknown configuration category '{category}'.")
 
     def categories(self) -> list[str]:
+        r"""
+        Return categories that currently contain entries.
+
+        Returns
+        -------
+        list[str]
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> manager.categories()
+        """
         return [
             category
             for category in self.NAMED_CATEGORIES
@@ -151,6 +304,29 @@ class ConfigurationManager:
         ]
 
     def keys(self, category: str | None = None) -> list[str]:
+        r"""
+        Return known entry names.
+
+        Parameters
+        ----------
+        category : str, optional
+            Restrict the result to one category.
+
+        Returns
+        -------
+        list[str]
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> manager.keys()
+
+        .. code-block:: python
+
+            >>> manager.keys("simulators")
+        """
         if category is None:
             names: list[str] = []
             for current_category in self.NAMED_CATEGORIES:
@@ -161,16 +337,84 @@ class ConfigurationManager:
         return list(self._items_by_category[category].keys())
 
     def has(self, category: str, name: str) -> bool:
+        r"""
+        Check whether a named entry exists.
+
+        Parameters
+        ----------
+        category : str
+            Category to inspect.
+        name : str
+            Entry name.
+
+        Returns
+        -------
+        bool
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> manager.has("simulators", "design")
+            True
+        """
         self._require_named_category(category)
         return name in self._items_by_category[category]
 
     def get(self, category: str, name: str) -> dict[str, Any]:
+        r"""
+        Return a named configuration entry.
+
+        Parameters
+        ----------
+        category : str
+            Category to inspect.
+        name : str
+            Entry name.
+
+        Returns
+        -------
+        dict[str, Any]
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> manager.get("simulators", "design")
+        """
         self._require_named_category(category)
         if name not in self._items_by_category[category]:
             raise KeyError(f"Configuration entry '{name}' not found in category '{category}'.")
         return self._strip_internal_metadata(copy.deepcopy(self._items_by_category[category][name]))
 
     def find(self, pattern: str, category: str | None = None) -> list[str]:
+        r"""
+        Search entry names using wildcards or regular expressions.
+
+        Parameters
+        ----------
+        pattern : str
+            Wildcard pattern or regular expression prefixed with ``re:``.
+        category : str, optional
+            Restrict the search to one category.
+
+        Returns
+        -------
+        list[str]
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> manager.find("BPM_C04*")
+
+        .. code-block:: python
+
+            >>> manager.find("re:^QF1.*$")
+        """
         if not pattern or not pattern.strip():
             raise PyAMLConfigException("Empty configuration query.")
 
@@ -187,8 +431,22 @@ class ConfigurationManager:
         return [name for name in names if fnmatch.fnmatch(name, pattern)]
 
     def settings(self) -> dict[str, Any]:
+        r"""
+        Return aggregated scalar accelerator settings.
+
+        Returns
+        -------
+        dict[str, Any]
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> manager.settings()
+        """
         settings: dict[str, Any] = {}
-        ordered_fields = [field for field in self.ROOT_FIELDS if field in self._state]
+        ordered_fields = [field for field in self.root_fields() if field in self._state]
         extra_fields = [
             field
             for field in self._state.keys()
@@ -201,12 +459,42 @@ class ConfigurationManager:
         return self._strip_internal_metadata(settings)
 
     def to_dict(self) -> dict[str, Any]:
+        r"""
+        Return the aggregated configuration as a plain dictionary.
+
+        Returns
+        -------
+        dict[str, Any]
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> snapshot = manager.to_dict()
+        """
         snapshot = self._snapshot(include_internal_metadata=False)
         return snapshot
 
     def build(self, ignore_external: bool = False):
-        """
+        r"""
         Build an Accelerator from the aggregated configuration snapshot.
+
+        Parameters
+        ----------
+        ignore_external : bool, optional
+            Forwarded to :meth:`pyaml.accelerator.Accelerator.from_dict`.
+
+        Returns
+        -------
+        Accelerator
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> sr = manager.build()
         """
         from ..accelerator import Accelerator
 
@@ -214,17 +502,48 @@ class ConfigurationManager:
         return Accelerator.from_dict(self._snapshot(include_internal_metadata=True), ignore_external=ignore_external)
 
     def __dir__(self):
+        """
+        Extend ``dir()`` with attribute-friendly entry names.
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> "HCORR" in dir(manager)
+        """
         default = super().__dir__()
         valid_keys = {key for key in self.keys() if _VALID_QUERY_KEY_RE.match(key)}
         return sorted(set(default) | valid_keys)
 
     def __getitem__(self, query: str) -> list[str]:
-        """
+        r"""
         Alias for :meth:`find`.
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> manager["BPM_C04*"]
         """
         return self.find(query)
 
     def __getattr__(self, name):
+        """
+        Provide attribute-style access for categories and unambiguous entry names.
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> manager.simulators
+
+        .. code-block:: python
+
+            >>> manager.HCORR
+        """
         if name in self._items_by_category:
             return self.keys(name)
         categories = self._categories_for_name(name)
@@ -238,6 +557,16 @@ class ConfigurationManager:
         raise AttributeError(f"'ConfigurationManager' object has no attribute '{name}'")
 
     def __repr__(self) -> str:
+        """
+        Return a human-readable overview of the aggregated configuration.
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> repr(manager)
+        """
         lines: list[str] = []
 
         settings = self.settings()
@@ -260,6 +589,16 @@ class ConfigurationManager:
         return "\n".join(lines).rstrip()
 
     def __str__(self) -> str:
+        """
+        Return the same overview as :meth:`__repr__`.
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            >>> print(manager)
+        """
         return self.__repr__()
 
     def _load_payload(
@@ -433,9 +772,9 @@ class ConfigurationManager:
 
         details: list[str] = []
         if category == "arrays":
-            selectors = entry.get("elements")
-            if isinstance(selectors, list):
-                details.append(f"selectors={len(selectors)}")
+            patterns = entry.get("elements")
+            if isinstance(patterns, list):
+                details.append(f"patterns={len(patterns)}")
 
         source = self._sources_by_category[category].get(name)
         if source is not None:

--- a/pyaml/configuration/manager.py
+++ b/pyaml/configuration/manager.py
@@ -19,12 +19,12 @@ import os
 import re
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 from ..common.exception import PyAMLConfigException
 from .fileloader import get_root_folder, load, set_root_folder
+from .restfetcher import REMOTE_BASE_URL_KEY, SourceRoot, fetch_remote_config, is_remote_url, resolve_reference
 
-_INTERNAL_METADATA_KEYS = {"__location__", "__fieldlocations__"}
+_INTERNAL_METADATA_KEYS = {"__location__", "__fieldlocations__", REMOTE_BASE_URL_KEY}
 _VALID_QUERY_KEY_RE = re.compile(r"^[A-Z0-9_]+$")
 _CATEGORY_TITLES = {
     "controls": "Controls",
@@ -111,7 +111,7 @@ class ConfigurationManager:
         }
         self._sources_by_category: dict[str, dict[str, str]] = {category: {} for category in self.NAMED_CATEGORIES}
         self._field_sources: dict[str, str] = {}
-        self._build_root: Path = get_root_folder()
+        self._build_root: SourceRoot = get_root_folder()
         self._build_root_locked = False
 
     def add(self, payload, **kwargs) -> None:
@@ -498,8 +498,10 @@ class ConfigurationManager:
         """
         from ..accelerator import Accelerator
 
-        set_root_folder(self._build_root)
-        return Accelerator.from_dict(self._snapshot(include_internal_metadata=True), ignore_external=ignore_external)
+        if isinstance(self._build_root, Path):
+            set_root_folder(self._build_root)
+        snapshot = self._strip_runtime_internal_metadata(self._snapshot(include_internal_metadata=True))
+        return Accelerator.from_dict(snapshot, ignore_external=ignore_external)
 
     def __dir__(self):
         """
@@ -607,14 +609,17 @@ class ConfigurationManager:
         *,
         source_name: str | None,
         use_fast_loader: bool,
-    ) -> tuple[dict[str, Any], str, Path | None]:
+    ) -> tuple[dict[str, Any], str, SourceRoot]:
         if isinstance(payload, dict):
             return copy.deepcopy(payload), source_name or "<dict>", None
 
         payload_path = self._coerce_path(payload)
-        parsed = urlparse(payload_path)
-        if parsed.scheme in {"http", "https"}:
-            raise PyAMLConfigException(f"REST configuration sources are not implemented yet for '{payload_path}'.")
+        if is_remote_url(payload_path):
+            fragment, source_root = fetch_remote_config(payload_path, use_fast_loader=use_fast_loader)
+            if not self._build_root_locked:
+                self._build_root = source_root
+                self._build_root_locked = True
+            return fragment, source_name or payload_path, source_root
 
         path = Path(payload_path)
         suffix = path.suffix.lower()
@@ -642,12 +647,7 @@ class ConfigurationManager:
 
         return fragment, source_name or str(resolved_path), source_root
 
-    def _prepare_fragment(
-        self,
-        fragment: dict[str, Any],
-        source_root: Path | None,
-        source_name: str,
-    ) -> dict[str, Any]:
+    def _prepare_fragment(self, fragment: dict[str, Any], source_root: SourceRoot, source_name: str) -> dict[str, Any]:
         if not isinstance(fragment, dict):
             raise PyAMLConfigException(
                 f"ConfigurationManager.add() expects a mapping at the top level, got '{type(fragment).__name__}'."
@@ -687,7 +687,7 @@ class ConfigurationManager:
                     )
 
                 if category == "simulators":
-                    self._normalize_simulator_paths(entry, source_root)
+                    self._normalize_simulator_paths(entry, entry.get(REMOTE_BASE_URL_KEY, source_root))
 
         return prepared
 
@@ -744,13 +744,13 @@ class ConfigurationManager:
             return snapshot
         return self._strip_internal_metadata(snapshot)
 
-    def _normalize_simulator_paths(self, entry: dict[str, Any], source_root: Path | None) -> None:
+    def _normalize_simulator_paths(self, entry: dict[str, Any], source_root: SourceRoot) -> None:
         if source_root is None:
             return
 
         lattice = entry.get("lattice")
-        if isinstance(lattice, str) and not os.path.isabs(lattice):
-            entry["lattice"] = str((source_root / lattice).resolve())
+        if isinstance(lattice, str) and not os.path.isabs(lattice) and not is_remote_url(lattice):
+            entry["lattice"] = resolve_reference(lattice, source_root)
 
     def _require_named_category(self, category: str) -> None:
         if category not in self.NAMED_CATEGORIES:
@@ -815,5 +815,16 @@ class ConfigurationManager:
                 key: self._strip_internal_metadata(entry)
                 for key, entry in value.items()
                 if key not in _INTERNAL_METADATA_KEYS
+            }
+        return value
+
+    def _strip_runtime_internal_metadata(self, value):
+        if isinstance(value, list):
+            return [self._strip_runtime_internal_metadata(entry) for entry in value]
+        if isinstance(value, dict):
+            return {
+                key: self._strip_runtime_internal_metadata(entry)
+                for key, entry in value.items()
+                if key != REMOTE_BASE_URL_KEY
             }
         return value

--- a/pyaml/configuration/manager.py
+++ b/pyaml/configuration/manager.py
@@ -700,23 +700,28 @@ class ConfigurationManager:
                 continue
 
             entries = fragment[category]
-            seen_in_fragment: set[str] = set()
+            seen_in_fragment: dict[str, dict[str, Any]] = {}
             for entry in entries:
                 name = entry["name"]
                 if name in seen_in_fragment:
+                    previous_entry = seen_in_fragment[name]
                     duplicate_errors.append(
-                        f"Configuration entry '{name}' is duplicated inside category '{category}' in source "
-                        f"'{source_name}'."
+                        f"Configuration entry '{name}' is duplicated inside category '{category}'. "
+                        f"First declaration: {self._describe_entry_source(previous_entry, source_name)}. "
+                        f"Duplicate declaration: {self._describe_entry_source(entry, source_name)}."
                     )
                     continue
                 if name in self._items_by_category[category]:
+                    previous_entry = self._items_by_category[category][name]
                     previous_source = self._sources_by_category[category].get(name, "<unknown>")
                     duplicate_errors.append(
-                        f"Configuration entry '{name}' already exists in category '{category}' "
-                        f"(from '{previous_source}'). Use replace() to override it."
+                        f"Configuration entry '{name}' already exists in category '{category}'. "
+                        f"First declaration: {self._describe_entry_source(previous_entry, previous_source)}. "
+                        f"Duplicate declaration: {self._describe_entry_source(entry, source_name)}. "
+                        "Use replace() to override it."
                     )
                     continue
-                seen_in_fragment.add(name)
+                seen_in_fragment[name] = entry
 
             pending_by_category[category] = entries
 
@@ -794,6 +799,13 @@ class ConfigurationManager:
         if suffix in self._SUPPORTED_FILE_SUFFIXES:
             return source_path.name
         return source
+
+    def _describe_entry_source(self, entry: dict[str, Any], fallback_source: str) -> str:
+        location = entry.get("__location__")
+        if isinstance(location, tuple) and len(location) == 3:
+            source, line, column = location
+            return f"source '{source}' at line {line}, column {column}"
+        return f"source '{fallback_source}'"
 
     def _coerce_path(self, payload) -> str:
         if isinstance(payload, (str, os.PathLike)):

--- a/pyaml/configuration/restfetcher.py
+++ b/pyaml/configuration/restfetcher.py
@@ -1,0 +1,194 @@
+"""
+HTTP configuration fetch helpers.
+"""
+
+import io
+import json
+import os
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlparse
+from urllib.request import ProxyHandler, build_opener
+
+import yaml
+from yaml import CLoader
+
+from ..common.exception import PyAMLConfigException
+from .fileloader import FILE_PREFIX, SafeLineLoader, accepted_suffixes
+
+REMOTE_BASE_URL_KEY = "__baseurl__"
+SourceRoot = Path | str | None
+_REMOTE_SCHEMES = {"http", "https"}
+
+
+class _NamedStringIO(io.StringIO):
+    def __init__(self, value: str, name: str):
+        super().__init__(value)
+        self.name = name
+
+
+def is_remote_url(value: str) -> bool:
+    return urlparse(value).scheme in _REMOTE_SCHEMES
+
+
+def fetch_remote_config(url: str, *, use_fast_loader: bool = False) -> tuple[dict[str, Any] | list[Any], str]:
+    normalized_url = _normalize_remote_url(url)
+    expanded = _load_remote_document(normalized_url, use_fast_loader=use_fast_loader, stack=[])
+    return expanded, _remote_base_url(normalized_url)
+
+
+def resolve_reference(reference: str, source_root: SourceRoot) -> str:
+    if is_remote_url(reference) or os.path.isabs(reference):
+        return reference
+
+    if isinstance(source_root, Path):
+        return str((source_root / reference).resolve())
+
+    if isinstance(source_root, str):
+        return urljoin(source_root, reference)
+
+    return reference
+
+
+def _normalize_remote_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme not in _REMOTE_SCHEMES:
+        raise PyAMLConfigException(f"Unsupported remote configuration source '{url}'.")
+    return url
+
+
+def _load_remote_document(
+    url: str,
+    *,
+    use_fast_loader: bool,
+    stack: list[str],
+) -> dict[str, Any] | list[Any]:
+    if url in stack:
+        raise PyAMLConfigException(f"Circular remote configuration inclusion detected for '{url}'.")
+
+    payload, content_type = _download_text(url)
+    document = _parse_remote_document(url, payload, content_type, use_fast_loader=use_fast_loader)
+    return _expand_remote_value(document, _remote_base_url(url), stack + [url], use_fast_loader=use_fast_loader)
+
+
+def _download_text(url: str) -> tuple[str, str]:
+    opener = build_opener(ProxyHandler({}))
+    try:
+        with opener.open(url, timeout=10) as response:
+            charset = response.headers.get_content_charset() or "utf-8"
+            content_type = response.headers.get_content_type()
+            body = response.read().decode(charset)
+            return body, content_type
+    except HTTPError as ex:
+        raise PyAMLConfigException(f"Unable to fetch remote configuration '{url}': HTTP {ex.code}.") from ex
+    except URLError as ex:
+        raise PyAMLConfigException(f"Unable to fetch remote configuration '{url}': {ex.reason}.") from ex
+    except OSError as ex:
+        raise PyAMLConfigException(f"Unable to fetch remote configuration '{url}': {ex}.") from ex
+
+
+def _parse_remote_document(
+    url: str,
+    payload: str,
+    content_type: str,
+    *,
+    use_fast_loader: bool,
+) -> dict[str, Any] | list[Any]:
+    suffix = Path(urlparse(url).path).suffix.lower()
+
+    if content_type == "application/json" or suffix == ".json":
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError as ex:
+            raise PyAMLConfigException(f"{url}: {ex}") from ex
+
+    loader = CLoader if use_fast_loader else SafeLineLoader
+    try:
+        stream = _NamedStringIO(payload, url)
+        return yaml.load(stream, Loader=loader)
+    except yaml.YAMLError as ex:
+        raise PyAMLConfigException(f"{url}: {ex}") from ex
+
+
+def _expand_remote_value(value, base_url: str, stack: list[str], *, use_fast_loader: bool):
+    if isinstance(value, dict):
+        return _expand_remote_dict(value, base_url, stack, use_fast_loader=use_fast_loader)
+    if isinstance(value, list):
+        return _expand_remote_list(value, base_url, stack, use_fast_loader=use_fast_loader)
+    return value
+
+
+def _expand_remote_dict(
+    values: dict[str, Any],
+    base_url: str,
+    stack: list[str],
+    *,
+    use_fast_loader: bool,
+) -> dict[str, Any]:
+    values.setdefault(REMOTE_BASE_URL_KEY, base_url)
+    for key, value in list(values.items()):
+        if _is_config_reference(value):
+            values[key] = _load_remote_document(
+                _resolve_remote_config_reference(value, base_url),
+                use_fast_loader=use_fast_loader,
+                stack=stack,
+            )
+            continue
+
+        if isinstance(value, str) and value.startswith(FILE_PREFIX):
+            values[key] = resolve_reference(value[len(FILE_PREFIX) :], base_url)
+            continue
+
+        values[key] = _expand_remote_value(value, base_url, stack, use_fast_loader=use_fast_loader)
+    return values
+
+
+def _expand_remote_list(values: list[Any], base_url: str, stack: list[str], *, use_fast_loader: bool) -> list[Any]:
+    index = 0
+    while index < len(values):
+        value = values[index]
+        if _is_config_reference(value):
+            expanded = _load_remote_document(
+                _resolve_remote_config_reference(value, base_url),
+                use_fast_loader=use_fast_loader,
+                stack=stack,
+            )
+            if isinstance(expanded, list):
+                values[index : index + 1] = expanded
+                index += len(expanded)
+            else:
+                values[index] = expanded
+                index += 1
+            continue
+
+        if isinstance(value, str) and value.startswith(FILE_PREFIX):
+            values[index] = resolve_reference(value[len(FILE_PREFIX) :], base_url)
+            index += 1
+            continue
+
+        values[index] = _expand_remote_value(value, base_url, stack, use_fast_loader=use_fast_loader)
+        index += 1
+    return values
+
+
+def _is_config_reference(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+
+    if value.startswith(FILE_PREFIX):
+        return False
+
+    parsed = urlparse(value)
+    path = parsed.path if parsed.scheme in _REMOTE_SCHEMES else value
+    return any(path.endswith(suffix) for suffix in accepted_suffixes)
+
+
+def _resolve_remote_config_reference(reference: str, base_url: str) -> str:
+    if is_remote_url(reference):
+        return reference
+    return urljoin(base_url, reference)
+
+
+def _remote_base_url(url: str) -> str:
+    return urljoin(url, ".")

--- a/tests/config/config_manager_base.yaml
+++ b/tests/config/config_manager_base.yaml
@@ -1,0 +1,11 @@
+type: pyaml.accelerator
+facility: Test Facility
+machine: test_ring
+energy: 3000000000.0
+data_folder: data
+description: Base configuration for ConfigurationManager tests
+simulators:
+  - type: pyaml.lattice.simulator
+    name: design
+    lattice: sr/lattices/ebs.mat
+devices: []

--- a/tests/config/config_manager_simulator.json
+++ b/tests/config/config_manager_simulator.json
@@ -1,0 +1,10 @@
+{
+  "simulators": [
+    {
+      "type": "pyaml.lattice.simulator",
+      "name": "analysis",
+      "lattice": "sr/lattices/ebs.mat",
+      "description": "Secondary simulation mode"
+    }
+  ]
+}

--- a/tests/config/config_manager_sr_arrays.yaml
+++ b/tests/config/config_manager_sr_arrays.yaml
@@ -1,0 +1,28 @@
+arrays:
+  - type: pyaml.arrays.magnet
+    name: HCORR
+    elements:
+      - SH1A-C0?-H
+  - type: pyaml.arrays.magnet
+    name: VCORR
+    elements:
+      - SH1A-C0?-V
+  - type: pyaml.arrays.magnet
+    name: HVCORR
+    elements:
+      - re:^SH1A-C0[12]-H$
+      - re:^SH1A-C0[12]-V$
+  - type: pyaml.arrays.cfm_magnet
+    name: CFM
+    elements:
+      - SH1A-C0?
+  - type: pyaml.arrays.bpm
+    name: BPMS
+    elements:
+      - BPM_C04-*
+  - type: pyaml.arrays.element
+    name: ElArray
+    elements:
+      - re:^BPM_C04-0[12]$
+      - SH1A-C01-V
+      - SH1A-C02-H

--- a/tests/config/config_manager_sr_base.yaml
+++ b/tests/config/config_manager_sr_base.yaml
@@ -1,0 +1,13 @@
+type: pyaml.accelerator
+facility: ESRF
+machine: sr
+energy: 6e9
+simulators:
+  - type: pyaml.lattice.simulator
+    lattice: sr/lattices/ebs.mat
+    name: design
+controls:
+  - type: tango.pyaml.controlsystem
+    tango_host: ebs-simu-3:10000
+    name: live
+data_folder: /data/store

--- a/tests/config/config_manager_sr_devices.yaml
+++ b/tests/config/config_manager_sr_devices.yaml
@@ -1,0 +1,27 @@
+devices:
+  - sr/quadrupoles/QF1AC01.yaml
+  - sr/correctors/SH1AC01-C02.yaml
+  - type: pyaml.bpm.bpm
+    name: BPM_C04-01
+    model:
+      type: pyaml.bpm.bpm_simple_model
+      x_pos:
+        type: tango.pyaml.attribute_read_only
+        attribute: srdiag/bpm/c04-01/SA_HPosition
+        unit: m
+      y_pos:
+        type: tango.pyaml.attribute_read_only
+        attribute: srdiag/bpm/c04-01/SA_VPosition
+        unit: m
+  - type: pyaml.bpm.bpm
+    name: BPM_C04-02
+    model:
+      type: pyaml.bpm.bpm_simple_model
+      x_pos:
+        type: tango.pyaml.attribute_read_only
+        attribute: srdiag/bpm/c04-02/SA_HPosition
+        unit: m
+      y_pos:
+        type: tango.pyaml.attribute_read_only
+        attribute: srdiag/bpm/c04-02/SA_VPosition
+        unit: m

--- a/tests/config/config_manager_tune_monitor_devices.yaml
+++ b/tests/config/config_manager_tune_monitor_devices.yaml
@@ -1,0 +1,11 @@
+devices:
+  - type: pyaml.diagnostics.tune_monitor
+    name: BETATRON_TUNE
+    tune_h:
+      type: tango.pyaml.attribute_read_only
+      attribute: srdiag/tune/tune_h
+      unit: mm
+    tune_v:
+      type: tango.pyaml.attribute_read_only
+      attribute: srdiag/tune/tune_v
+      unit: mm

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib.machinery
 import pathlib
 import sys
 import types
@@ -59,6 +60,7 @@ def install_test_package(request):
     _purge_modules(package_roots)
     if package_path_str not in sys.path:
         sys.path.insert(0, package_path_str)
+    _expose_namespace_packages(package_path)
     importlib.invalidate_caches()
 
     yield package_name
@@ -96,6 +98,31 @@ def _purge_modules(package_roots: list[str]) -> None:
                 sys.modules.pop(module_name, None)
 
 
+def _expose_namespace_packages(package_path: pathlib.Path) -> None:
+    for child in package_path.iterdir():
+        if child.name.startswith(".") or not child.is_dir():
+            continue
+        if (child / "__init__.py").exists():
+            continue
+
+        module = sys.modules.get(child.name)
+        if module is None:
+            try:
+                module = importlib.import_module(child.name)
+            except ModuleNotFoundError:
+                module = types.ModuleType(child.name)
+                module.__path__ = []
+                module.__package__ = child.name
+                module.__spec__ = importlib.machinery.ModuleSpec(child.name, loader=None, is_package=True)
+                sys.modules[child.name] = module
+
+        module_path = list(getattr(module, "__path__", []))
+        child_str = str(child)
+        if child_str not in module_path:
+            module_path.append(child_str)
+            module.__path__ = module_path
+
+
 @pytest.fixture(scope="session", autouse=True)
 def install_default_test_packages():
     package_paths = [
@@ -114,6 +141,8 @@ def install_default_test_packages():
     for path_string in reversed(path_strings):
         if path_string not in sys.path:
             sys.path.insert(0, path_string)
+    for package_path in package_paths:
+        _expose_namespace_packages(package_path)
     importlib.invalidate_caches()
 
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 import importlib
 import importlib.machinery
+import importlib.metadata
 import pathlib
 import sys
 import types
 from contextlib import contextmanager
+from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Thread
 
@@ -16,10 +18,31 @@ from pyaml.configuration import ConfigurationManager
 from pyaml.configuration.factory import BuildStrategy, Factory
 from pyaml.control.readback_value import Value
 
-_TEST_PACKAGE_IMPORTS = {
-    "tango-pyaml": "tango.pyaml.controlsystem",
-    "pyaml_external": "pyaml_external.external_magnet_model",
+
+@dataclass(frozen=True)
+class TestPackageSpec:
+    import_name: str
+    distribution_name: str
+    module_file: str
+    local_path: pathlib.Path
+
+
+_TEST_PACKAGES = {
+    "tango-pyaml": TestPackageSpec(
+        import_name="tango.pyaml.controlsystem",
+        distribution_name="tango-pyaml",
+        module_file="tango/pyaml/controlsystem.py",
+        local_path=pathlib.Path("tests/dummy_cs/tango-pyaml"),
+    ),
+    "pyaml_external": TestPackageSpec(
+        import_name="pyaml_external.external_magnet_model",
+        distribution_name="pyaml_external",
+        module_file="pyaml_external/external_magnet_model.py",
+        local_path=pathlib.Path("tests/external"),
+    ),
 }
+_TESTS_DIR = pathlib.Path(__file__).parent.resolve()
+_CONFIG_DIR = _TESTS_DIR / "config"
 
 
 @pytest.fixture
@@ -47,38 +70,10 @@ def install_test_package(request):
         yield None
         return
     package_name = info["name"]
-    package_path = None
-    if info["path"] is not None:
-        package_path = pathlib.Path(info["path"]).resolve()
-        if not package_path.exists():
-            raise FileNotFoundError(f"Package path not found: {package_path}")
+    package_path = _resolve_test_package_path(info)
 
-    if package_path is None:
-        raise RuntimeError("No package_path defined for install_test_package fixture")
-
-    if not ((package_path / "pyproject.toml").exists() or (package_path / "setup.py").exists()):
-        raise RuntimeError(f"No pyproject.toml or setup.py found in {package_path}")
-
-    target_import = _TEST_PACKAGE_IMPORTS.get(package_name)
-    if target_import and _module_available(target_import):
+    with _installed_test_packages([package_path], skip_if_installed=(package_name,)):
         yield package_name
-        return
-
-    package_path_str = str(package_path)
-    package_roots = _discover_package_roots(package_path)
-
-    _purge_modules(package_roots)
-    if package_path_str not in sys.path:
-        sys.path.insert(0, package_path_str)
-    _expose_namespace_packages(package_path)
-    importlib.invalidate_caches()
-
-    yield package_name
-
-    _purge_modules(package_roots)
-    while package_path_str in sys.path:
-        sys.path.remove(package_path_str)
-    importlib.invalidate_caches()
 
 
 def _discover_package_roots(package_path: pathlib.Path) -> list[str]:
@@ -101,12 +96,62 @@ def _discover_package_roots(package_path: pathlib.Path) -> list[str]:
     return list(dict.fromkeys(roots))
 
 
+def _resolve_test_package_path(info: dict) -> pathlib.Path:
+    package_path_value = info.get("path")
+    if package_path_value is None:
+        raise RuntimeError("No package_path defined for install_test_package fixture")
+
+    package_path = pathlib.Path(package_path_value).resolve()
+    if not package_path.exists():
+        raise FileNotFoundError(f"Package path not found: {package_path}")
+    if not ((package_path / "pyproject.toml").exists() or (package_path / "setup.py").exists()):
+        raise RuntimeError(f"No pyproject.toml or setup.py found in {package_path}")
+    return package_path
+
+
 def _module_available(module_name: str) -> bool:
     try:
         importlib.import_module(module_name)
     except ModuleNotFoundError:
         return False
     return True
+
+
+def _imported_module_path(module_name: str) -> pathlib.Path | None:
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        return None
+
+    module_file = getattr(module, "__file__", None)
+    if module_file is None:
+        return None
+    return pathlib.Path(module_file).resolve()
+
+
+def _installed_module_path(spec: TestPackageSpec) -> pathlib.Path | None:
+    try:
+        distribution = importlib.metadata.distribution(spec.distribution_name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+    module_path = pathlib.Path(distribution.locate_file(spec.module_file)).resolve()
+    return module_path if module_path.exists() else None
+
+
+def _module_matches_test_package(package_name: str, package_path: pathlib.Path) -> bool:
+    spec = _TEST_PACKAGES.get(package_name)
+    if spec is None:
+        return False
+
+    module_path = _imported_module_path(spec.import_name)
+    if module_path is None:
+        return False
+    if module_path.is_relative_to(package_path):
+        return True
+
+    installed_module_path = _installed_module_path(spec)
+    return installed_module_path is not None and module_path == installed_module_path
 
 
 def _purge_modules(package_roots: list[str]) -> None:
@@ -141,22 +186,28 @@ def _expose_namespace_packages(package_path: pathlib.Path) -> None:
             module.__path__ = module_path
 
 
-@pytest.fixture(scope="session", autouse=True)
-def install_default_test_packages():
-    package_paths = [
-        pathlib.Path("tests/dummy_cs/tango-pyaml").resolve(),
-        pathlib.Path("tests/external").resolve(),
-    ]
-    if all(_module_available(module_name) for module_name in _TEST_PACKAGE_IMPORTS.values()):
-        yield
-        return
+@contextmanager
+def _installed_test_packages(
+    package_paths: list[pathlib.Path],
+    *,
+    skip_if_installed: tuple[str, ...] = (),
+):
+    if skip_if_installed:
+        package_map = {
+            package_name: _TEST_PACKAGES[package_name].local_path.resolve()
+            for package_name in skip_if_installed
+            if package_name in _TEST_PACKAGES
+        }
+        if package_map and all(
+            _module_matches_test_package(package_name, package_path)
+            for package_name, package_path in package_map.items()
+        ):
+            yield
+            return
 
-    package_roots: list[str] = []
-
-    for package_path in package_paths:
-        package_roots.extend(_discover_package_roots(package_path))
-
-    package_roots = list(dict.fromkeys(package_roots))
+    package_roots = list(
+        dict.fromkeys(root for package_path in package_paths for root in _discover_package_roots(package_path))
+    )
     path_strings = [str(path) for path in package_paths]
 
     _purge_modules(package_roots)
@@ -167,13 +218,24 @@ def install_default_test_packages():
         _expose_namespace_packages(package_path)
     importlib.invalidate_caches()
 
-    yield
+    try:
+        yield
+    finally:
+        _purge_modules(package_roots)
+        for path_string in path_strings:
+            while path_string in sys.path:
+                sys.path.remove(path_string)
+        importlib.invalidate_caches()
 
-    _purge_modules(package_roots)
-    for path_string in path_strings:
-        while path_string in sys.path:
-            sys.path.remove(path_string)
-    importlib.invalidate_caches()
+
+@pytest.fixture(scope="session", autouse=True)
+def install_default_test_packages():
+    package_paths = [spec.local_path.resolve() for spec in _TEST_PACKAGES.values()]
+    with _installed_test_packages(
+        package_paths,
+        skip_if_installed=tuple(_TEST_PACKAGES),
+    ):
+        yield
 
 
 @pytest.fixture
@@ -196,7 +258,7 @@ def config_root_path() -> pathlib.Path:
     """
     Returns the absolute path to the `tests/config` directory as a Path.
     """
-    return (pathlib.Path(__file__).parent / "config").resolve()
+    return _CONFIG_DIR
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@ import importlib
 import pathlib
 import sys
 import types
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
 
 import at
 import numpy as np
@@ -186,6 +189,50 @@ def tune_monitor_configuration_fragments(
     tune_monitor_devices_fragment,
 ) -> tuple[pathlib.Path, pathlib.Path]:
     return (sr_base_fragment, tune_monitor_devices_fragment)
+
+
+@pytest.fixture
+def http_config_server():
+    @contextmanager
+    def _serve(routes: dict[str, str | tuple[str, str, int]]):
+        normalized_routes: dict[str, tuple[bytes, str, int]] = {}
+        for path, response in routes.items():
+            body: str
+            content_type = "text/plain"
+            status = 200
+            if isinstance(response, tuple):
+                body, content_type, status = response
+            else:
+                body = response
+            normalized_routes[path] = (body.encode("utf-8"), content_type, status)
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                payload, content_type, status = normalized_routes.get(
+                    self.path,
+                    (b"not found", "text/plain", 404),
+                )
+                self.send_response(status)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, format, *args):
+                return
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        base_url = f"http://127.0.0.1:{server.server_address[1]}"
+        try:
+            yield base_url
+        finally:
+            server.shutdown()
+            thread.join()
+            server.server_close()
+
+    return _serve
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -327,10 +327,9 @@ def tune_monitor_devices_fragment(config_root_path) -> pathlib.Path:
 
 @pytest.fixture
 def tune_monitor_configuration_fragments(
-    sr_base_fragment,
-    tune_monitor_devices_fragment,
-) -> tuple[pathlib.Path, pathlib.Path]:
-    return (sr_base_fragment, tune_monitor_devices_fragment)
+    config_root_path,
+) -> tuple[pathlib.Path]:
+    return (config_root_path / "tune_monitor.yaml",)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,11 @@ from pyaml.configuration import ConfigurationManager
 from pyaml.configuration.factory import BuildStrategy, Factory
 from pyaml.control.readback_value import Value
 
+_TEST_PACKAGE_IMPORTS = {
+    "tango-pyaml": "tango.pyaml.controlsystem",
+    "pyaml_external": "pyaml_external.external_magnet_model",
+}
+
 
 @pytest.fixture
 def install_test_package(request):
@@ -54,6 +59,11 @@ def install_test_package(request):
     if not ((package_path / "pyproject.toml").exists() or (package_path / "setup.py").exists()):
         raise RuntimeError(f"No pyproject.toml or setup.py found in {package_path}")
 
+    target_import = _TEST_PACKAGE_IMPORTS.get(package_name)
+    if target_import and _module_available(target_import):
+        yield package_name
+        return
+
     package_path_str = str(package_path)
     package_roots = _discover_package_roots(package_path)
 
@@ -89,6 +99,14 @@ def _discover_package_roots(package_path: pathlib.Path) -> list[str]:
             roots.append(child.stem)
 
     return list(dict.fromkeys(roots))
+
+
+def _module_available(module_name: str) -> bool:
+    try:
+        importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        return False
+    return True
 
 
 def _purge_modules(package_roots: list[str]) -> None:
@@ -129,6 +147,10 @@ def install_default_test_packages():
         pathlib.Path("tests/dummy_cs/tango-pyaml").resolve(),
         pathlib.Path("tests/external").resolve(),
     ]
+    if all(_module_available(module_name) for module_name in _TEST_PACKAGE_IMPORTS.values()):
+        yield
+        return
+
     package_roots: list[str] = []
 
     for package_path in package_paths:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,35 @@ def _purge_modules(package_roots: list[str]) -> None:
                 sys.modules.pop(module_name, None)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def install_default_test_packages():
+    package_paths = [
+        pathlib.Path("tests/dummy_cs/tango-pyaml").resolve(),
+        pathlib.Path("tests/external").resolve(),
+    ]
+    package_roots: list[str] = []
+
+    for package_path in package_paths:
+        package_roots.extend(_discover_package_roots(package_path))
+
+    package_roots = list(dict.fromkeys(package_roots))
+    path_strings = [str(path) for path in package_paths]
+
+    _purge_modules(package_roots)
+    for path_string in reversed(path_strings):
+        if path_string not in sys.path:
+            sys.path.insert(0, path_string)
+    importlib.invalidate_caches()
+
+    yield
+
+    _purge_modules(package_roots)
+    for path_string in path_strings:
+        while path_string in sys.path:
+            sys.path.remove(path_string)
+    importlib.invalidate_caches()
+
+
 @pytest.fixture
 def accelerator_from_fragments():
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
+import importlib
 import pathlib
-import subprocess
 import sys
 import types
 
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from pydantic import BaseModel
 
+from pyaml.configuration import ConfigurationManager
 from pyaml.configuration.factory import BuildStrategy, Factory
 from pyaml.control.readback_value import Value
 
@@ -15,10 +16,10 @@ from pyaml.control.readback_value import Value
 @pytest.fixture
 def install_test_package(request):
     """
-    Temporarily install a test package and uninstall it after the test.
+    Temporarily expose a local test package on ``sys.path`` for the test.
 
     The test must provide a dictionary as parameter with:
-    - 'name': name of the installable package (used for pip uninstall)
+    - 'name': logical package name
     - 'path': relative path to the package folder (e.g. 'tests/my_dir').
       Optional, replaced by package name if absent.
 
@@ -46,33 +47,145 @@ def install_test_package(request):
     if package_path is None:
         raise RuntimeError("No package_path defined for install_test_package fixture")
 
-    if not (
-        (package_path / "pyproject.toml").exists()
-        or (package_path / "setup.py").exists()
-    ):
+    if not ((package_path / "pyproject.toml").exists() or (package_path / "setup.py").exists()):
         raise RuntimeError(f"No pyproject.toml or setup.py found in {package_path}")
 
-    """Install package in a classis way, `--editable` create a .pth entry
-    in conda env which is imcompatible with submodule"""
-    if package_path is not None:
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "--quiet", "install", str(package_path)]
-        )
+    package_path_str = str(package_path)
+    package_roots = _discover_package_roots(package_path)
+
+    _purge_modules(package_roots)
+    if package_path_str not in sys.path:
+        sys.path.insert(0, package_path_str)
+    importlib.invalidate_caches()
 
     yield package_name
 
-    # Do not uninstall package at the end to speed up tests a bit
-    # subprocess.call([
-    #    sys.executable, "-m", "pip", "uninstall", "-y", package_name
-    # ])
+    _purge_modules(package_roots)
+    while package_path_str in sys.path:
+        sys.path.remove(package_path_str)
+    importlib.invalidate_caches()
+
+
+def _discover_package_roots(package_path: pathlib.Path) -> list[str]:
+    roots: list[str] = []
+
+    for top_level_file in package_path.glob("*.egg-info/top_level.txt"):
+        roots.extend(line.strip() for line in top_level_file.read_text().splitlines() if line.strip())
+
+    if roots:
+        return list(dict.fromkeys(roots))
+
+    for child in package_path.iterdir():
+        if child.name.startswith("."):
+            continue
+        if child.is_dir():
+            roots.append(child.name)
+        elif child.suffix == ".py":
+            roots.append(child.stem)
+
+    return list(dict.fromkeys(roots))
+
+
+def _purge_modules(package_roots: list[str]) -> None:
+    for root in package_roots:
+        for module_name in list(sys.modules):
+            if module_name == root or module_name.startswith(f"{root}."):
+                sys.modules.pop(module_name, None)
 
 
 @pytest.fixture
-def config_root_dir():
+def accelerator_from_fragments():
+    """
+    Build an accelerator explicitly from a list of configuration fragments.
+    """
+
+    def _build(*fragments, ignore_external: bool = False):
+        manager = ConfigurationManager()
+        for fragment in fragments:
+            manager.add(fragment)
+        return manager.build(ignore_external=ignore_external)
+
+    return _build
+
+
+@pytest.fixture
+def config_root_path() -> pathlib.Path:
+    """
+    Returns the absolute path to the `tests/config` directory as a Path.
+    """
+    return (pathlib.Path(__file__).parent / "config").resolve()
+
+
+@pytest.fixture
+def config_root_dir(config_root_path):
     """
     Returns the absolute path to the `tests/config` directory.
     """
-    return str((pathlib.Path(__file__).parent / "config").resolve())
+    return str(config_root_path)
+
+
+@pytest.fixture
+def config_manager_base_config(config_root_path) -> pathlib.Path:
+    return config_root_path / "config_manager_base.yaml"
+
+
+@pytest.fixture
+def config_manager_simulator_json(config_root_path) -> pathlib.Path:
+    return config_root_path / "config_manager_simulator.json"
+
+
+@pytest.fixture
+def ebs_lattice_file(config_root_path) -> pathlib.Path:
+    return (config_root_path / "sr" / "lattices" / "ebs.mat").resolve()
+
+
+@pytest.fixture
+def simulator_fragment_factory(ebs_lattice_file):
+    def _build(name: str) -> dict:
+        return {
+            "type": "pyaml.lattice.simulator",
+            "name": name,
+            "lattice": str(ebs_lattice_file),
+        }
+
+    return _build
+
+
+@pytest.fixture
+def sr_base_fragment(config_root_path) -> pathlib.Path:
+    return config_root_path / "config_manager_sr_base.yaml"
+
+
+@pytest.fixture
+def sr_arrays_fragment(config_root_path) -> pathlib.Path:
+    return config_root_path / "config_manager_sr_arrays.yaml"
+
+
+@pytest.fixture
+def sr_devices_fragment(config_root_path) -> pathlib.Path:
+    return config_root_path / "config_manager_sr_devices.yaml"
+
+
+@pytest.fixture
+def sr_configuration_fragments(
+    sr_base_fragment,
+    sr_arrays_fragment,
+    sr_devices_fragment,
+) -> tuple[pathlib.Path, pathlib.Path, pathlib.Path]:
+    return (sr_base_fragment, sr_arrays_fragment, sr_devices_fragment)
+
+
+@pytest.fixture
+def tune_monitor_devices_fragment(config_root_path) -> pathlib.Path:
+    return config_root_path / "config_manager_tune_monitor_devices.yaml"
+
+
+@pytest.fixture
+def tune_monitor_configuration_fragments(
+    sr_base_fragment,
+    tune_monitor_devices_fragment,
+) -> tuple[pathlib.Path, pathlib.Path]:
+    return (sr_base_fragment, tune_monitor_devices_fragment)
 
 
 @pytest.fixture

--- a/tests/test_accelerator_load.py
+++ b/tests/test_accelerator_load.py
@@ -1,0 +1,12 @@
+import pytest
+
+from pyaml import PyAMLConfigException
+from pyaml.accelerator import Accelerator
+
+
+def test_accelerator_load_rejects_non_accelerator_root(tmp_path):
+    config_file = tmp_path / "quadrupole.yaml"
+    config_file.write_text("type: pyaml.magnet.quadrupole\nname: QF1A-C01\n", encoding="utf-8")
+
+    with pytest.raises(PyAMLConfigException, match="Accelerator.load\\(\\) expects a 'pyaml.accelerator' root"):
+        Accelerator.load(str(config_file))

--- a/tests/test_accelerator_load.py
+++ b/tests/test_accelerator_load.py
@@ -10,3 +10,34 @@ def test_accelerator_load_rejects_non_accelerator_root(tmp_path):
 
     with pytest.raises(PyAMLConfigException, match="Accelerator.load\\(\\) expects a 'pyaml.accelerator' root"):
         Accelerator.load(str(config_file))
+
+
+def test_accelerator_load_supports_remote_sources(http_config_server, ebs_lattice_file):
+    routes = {
+        "/config/accelerator.yaml": """
+type: pyaml.accelerator
+facility: Remote Facility
+machine: remote_ring
+energy: 3000000000.0
+data_folder: remote-data
+description: Remote accelerator
+simulators: fragments/simulators.json
+devices: []
+""",
+        "/config/fragments/simulators.json": f"""
+[
+  {{
+    "type": "pyaml.lattice.simulator",
+    "name": "design",
+    "lattice": "{ebs_lattice_file.as_posix()}"
+  }}
+]
+""",
+    }
+
+    with http_config_server(routes) as base_url:
+        accelerator = Accelerator.load(f"{base_url}/config/accelerator.yaml")
+
+    assert isinstance(accelerator, Accelerator)
+    assert accelerator.design.name() == "design"
+    assert accelerator.get_description() == "Remote accelerator"

--- a/tests/test_arrays_ops.py
+++ b/tests/test_arrays_ops.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from pyaml.accelerator import Accelerator
 from pyaml.arrays.element_array import ElementArray
 from pyaml.arrays.magnet_array import MagnetArray
 from pyaml.configuration.factory import Factory
@@ -13,8 +12,10 @@ from pyaml.magnet.magnet import Magnet
     [{"name": "tango-pyaml", "path": "tests/dummy_cs/tango-pyaml"}],
     indirect=True,
 )
-def test_element_array_and_array_intersection_is_autotyped(install_test_package):
-    sr: Accelerator = Accelerator.load("tests/config/sr.yaml")
+def test_element_array_and_array_intersection_is_autotyped(
+    install_test_package, accelerator_from_fragments, sr_configuration_fragments
+):
+    sr = accelerator_from_fragments(*sr_configuration_fragments)
     sr.design.get_lattice().disable_6d()
 
     hcorr = sr.live.get_magnets("HCORR")
@@ -35,8 +36,10 @@ def test_element_array_and_array_intersection_is_autotyped(install_test_package)
 )
 def test_element_array_and_mask_filters_and_is_autotyped_list_mask(
     install_test_package,
+    accelerator_from_fragments,
+    sr_configuration_fragments,
 ):
-    sr: Accelerator = Accelerator.load("tests/config/sr.yaml")
+    sr = accelerator_from_fragments(*sr_configuration_fragments)
     sr.design.get_lattice().disable_6d()
 
     # "ElArray" is a mixed ElementArray in the dummy config (see existing tests)
@@ -62,8 +65,10 @@ def test_element_array_and_mask_filters_and_is_autotyped_list_mask(
 )
 def test_element_array_and_mask_filters_and_is_autotyped_numpy_mask(
     install_test_package,
+    accelerator_from_fragments,
+    sr_configuration_fragments,
 ):
-    sr: Accelerator = Accelerator.load("tests/config/sr.yaml")
+    sr = accelerator_from_fragments(*sr_configuration_fragments)
     sr.design.get_lattice().disable_6d()
 
     elts = sr.design.get_elements("ElArray")
@@ -86,8 +91,10 @@ def test_element_array_and_mask_filters_and_is_autotyped_numpy_mask(
     [{"name": "tango-pyaml", "path": "tests/dummy_cs/tango-pyaml"}],
     indirect=True,
 )
-def test_element_array_sub_mask_removes_true_inverse_of_and(install_test_package):
-    sr: Accelerator = Accelerator.load("tests/config/sr.yaml")
+def test_element_array_sub_mask_removes_true_inverse_of_and(
+    install_test_package, accelerator_from_fragments, sr_configuration_fragments
+):
+    sr = accelerator_from_fragments(*sr_configuration_fragments)
     sr.design.get_lattice().disable_6d()
 
     elts = sr.design.get_elements("ElArray")
@@ -121,8 +128,10 @@ def test_element_array_sub_mask_removes_true_inverse_of_and(install_test_package
 )
 def test_element_array_mask_length_mismatch_raises_for_and_and_sub(
     install_test_package,
+    accelerator_from_fragments,
+    sr_configuration_fragments,
 ):
-    sr: Accelerator = Accelerator.load("tests/config/sr.yaml")
+    sr = accelerator_from_fragments(*sr_configuration_fragments)
     sr.design.get_lattice().disable_6d()
 
     elts = sr.design.get_elements("ElArray")
@@ -144,8 +153,10 @@ def test_element_array_mask_length_mismatch_raises_for_and_and_sub(
     [{"name": "tango-pyaml", "path": "tests/dummy_cs/tango-pyaml"}],
     indirect=True,
 )
-def test_mask_by_type_returns_correct_boolean_mask(install_test_package):
-    sr: Accelerator = Accelerator.load("tests/config/sr.yaml")
+def test_mask_by_type_returns_correct_boolean_mask(
+    install_test_package, accelerator_from_fragments, sr_configuration_fragments
+):
+    sr = accelerator_from_fragments(*sr_configuration_fragments)
     sr.design.get_lattice().disable_6d()
 
     elts = sr.design.get_elements("ElArray")
@@ -167,8 +178,10 @@ def test_mask_by_type_returns_correct_boolean_mask(install_test_package):
     [{"name": "tango-pyaml", "path": "tests/dummy_cs/tango-pyaml"}],
     indirect=True,
 )
-def test_filter_by_type_returns_autotyped_array(install_test_package):
-    sr: Accelerator = Accelerator.load("tests/config/sr.yaml")
+def test_filter_by_type_returns_autotyped_array(
+    install_test_package, accelerator_from_fragments, sr_configuration_fragments
+):
+    sr = accelerator_from_fragments(*sr_configuration_fragments)
     sr.design.get_lattice().disable_6d()
 
     elts = sr.design.get_elements("ElArray")
@@ -186,8 +199,10 @@ def test_filter_by_type_returns_autotyped_array(install_test_package):
     [{"name": "tango-pyaml", "path": "tests/dummy_cs/tango-pyaml"}],
     indirect=True,
 )
-def test_element_array_or_union_is_unique_stable_and_autotyped(install_test_package):
-    sr: Accelerator = Accelerator.load("tests/config/sr.yaml")
+def test_element_array_or_union_is_unique_stable_and_autotyped(
+    install_test_package, accelerator_from_fragments, sr_configuration_fragments
+):
+    sr = accelerator_from_fragments(*sr_configuration_fragments)
     sr.design.get_lattice().disable_6d()
 
     hcorr = sr.live.get_magnets("HCORR")
@@ -213,8 +228,10 @@ def test_element_array_or_union_is_unique_stable_and_autotyped(install_test_pack
     [{"name": "tango-pyaml", "path": "tests/dummy_cs/tango-pyaml"}],
     indirect=True,
 )
-def test_element_array_add_is_alias_of_union(install_test_package):
-    sr: Accelerator = Accelerator.load("tests/config/sr.yaml")
+def test_element_array_add_is_alias_of_union(
+    install_test_package, accelerator_from_fragments, sr_configuration_fragments
+):
+    sr = accelerator_from_fragments(*sr_configuration_fragments)
     sr.design.get_lattice().disable_6d()
 
     hcorr = sr.live.get_magnets("HCORR")

--- a/tests/test_configuration_manager.py
+++ b/tests/test_configuration_manager.py
@@ -1,0 +1,198 @@
+from pathlib import Path
+
+import pytest
+
+from pyaml import PyAMLConfigException
+from pyaml.accelerator import Accelerator
+from pyaml.configuration import ConfigurationManager
+
+
+def test_configuration_manager_add_from_dict(
+    simulator_fragment_factory,
+    ebs_lattice_file,
+):
+    manager = ConfigurationManager()
+
+    manager.add(
+        {
+            "facility": "Dict Facility",
+            "machine": "dict_ring",
+            "energy": 3.0e9,
+            "data_folder": "data",
+            "simulators": [simulator_fragment_factory("design")],
+            "devices": [],
+        },
+        source_name="dict-fixture",
+    )
+
+    assert manager.categories() == ["simulators"]
+    assert manager.keys() == ["design"]
+    assert manager.keys("simulators") == ["design"]
+    assert manager.has("simulators", "design")
+    assert manager.find("des*") == ["design"]
+    assert manager.get("simulators", "design")["lattice"] == str(ebs_lattice_file)
+
+
+def test_configuration_manager_add_from_yaml_and_json(
+    config_manager_base_config,
+    config_manager_simulator_json,
+):
+    manager = ConfigurationManager()
+
+    manager.add(config_manager_base_config)
+    manager.add(config_manager_simulator_json)
+
+    assert manager.categories() == ["simulators"]
+    assert manager.keys("simulators") == ["design", "analysis"]
+    assert Path(manager.get("simulators", "design")["lattice"]).is_absolute()
+    assert manager.get("simulators", "analysis")["description"] == "Secondary simulation mode"
+
+
+def test_configuration_manager_remove_named_entry(
+    config_manager_base_config,
+    simulator_fragment_factory,
+):
+    manager = ConfigurationManager()
+    manager.add(config_manager_base_config)
+    manager.add({"simulators": [simulator_fragment_factory("tracking")]})
+
+    manager.remove("simulators", "tracking")
+
+    assert manager.keys("simulators") == ["design"]
+    assert not manager.has("simulators", "tracking")
+
+
+def test_configuration_manager_replace_named_entry(
+    config_manager_base_config,
+    ebs_lattice_file,
+):
+    manager = ConfigurationManager()
+    manager.add(config_manager_base_config)
+
+    manager.replace(
+        "simulators",
+        {
+            "type": "pyaml.lattice.simulator",
+            "name": "design",
+            "lattice": str(ebs_lattice_file),
+            "description": "Replaced simulator",
+        },
+    )
+
+    assert manager.get("simulators", "design")["description"] == "Replaced simulator"
+
+
+def test_configuration_manager_clear_category_and_settings(
+    config_manager_base_config,
+    simulator_fragment_factory,
+):
+    manager = ConfigurationManager()
+    manager.add(config_manager_base_config)
+    manager.add({"simulators": [simulator_fragment_factory("tracking")]})
+
+    manager.clear("simulators")
+
+    assert manager.keys("simulators") == []
+    assert manager.categories() == []
+    assert manager.settings()["facility"] == "Test Facility"
+
+    manager.clear()
+
+    assert manager.to_dict() == {"type": "pyaml.accelerator"}
+
+
+def test_configuration_manager_to_dict_snapshot_can_be_reloaded(
+    config_manager_base_config,
+    simulator_fragment_factory,
+):
+    manager = ConfigurationManager()
+    manager.add(config_manager_base_config)
+    manager.add({"simulators": [simulator_fragment_factory("tracking")]})
+
+    snapshot = manager.to_dict()
+
+    reloaded = ConfigurationManager()
+    reloaded.add(snapshot)
+
+    assert reloaded.to_dict() == snapshot
+
+
+def test_configuration_manager_build_explicitly(
+    config_manager_base_config,
+    simulator_fragment_factory,
+):
+    manager = ConfigurationManager()
+    manager.add(config_manager_base_config)
+    manager.add({"simulators": [simulator_fragment_factory("tracking")]})
+
+    accelerator = manager.build()
+
+    assert isinstance(accelerator, Accelerator)
+    assert accelerator.design.name() == "design"
+    assert accelerator.simulators()["tracking"].name() == "tracking"
+
+
+def test_accelerator_load_stays_compatible(config_manager_base_config):
+    accelerator = Accelerator.load(config_manager_base_config)
+
+    assert isinstance(accelerator, Accelerator)
+    assert accelerator.design.name() == "design"
+    assert accelerator.get_description() == "Base configuration for ConfigurationManager tests"
+
+
+def test_configuration_manager_rejects_duplicate_names(
+    config_manager_base_config,
+    simulator_fragment_factory,
+):
+    manager = ConfigurationManager()
+    manager.add(config_manager_base_config)
+
+    with pytest.raises(PyAMLConfigException, match="already exists in category 'simulators'"):
+        manager.add({"simulators": [simulator_fragment_factory("design")]})
+
+
+def test_configuration_manager_rejects_rest_source_explicitly():
+    manager = ConfigurationManager()
+
+    with pytest.raises(PyAMLConfigException, match="REST configuration sources are not implemented yet"):
+        manager.add("https://example.org/config")
+
+
+def test_configuration_manager_repr_is_yellow_pages_like(
+    sr_base_fragment,
+    sr_arrays_fragment,
+    sr_devices_fragment,
+):
+    manager = ConfigurationManager()
+    manager.add(sr_base_fragment)
+    manager.add(sr_arrays_fragment)
+    manager.add(sr_devices_fragment)
+
+    output = repr(manager)
+
+    assert str(manager) == output
+    assert "Settings:" in output
+    assert "Controls:" in output
+    assert "Simulators:" in output
+    assert "Arrays:" in output
+    assert "Devices:" in output
+    assert "live (tango.pyaml.controlsystem) source=config_manager_sr_base.yaml" in output
+    assert "design (pyaml.lattice.simulator) source=config_manager_sr_base.yaml" in output
+    assert "HCORR (pyaml.arrays.magnet) selectors=1 source=config_manager_sr_arrays.yaml" in output
+    assert "BPM_C04-01 (pyaml.bpm.bpm) source=config_manager_sr_devices.yaml" in output
+    assert "    ." in output
+
+
+def test_configuration_manager_yellow_pages_like_shortcuts(
+    sr_base_fragment,
+    sr_arrays_fragment,
+    sr_devices_fragment,
+):
+    manager = ConfigurationManager()
+    manager.add(sr_base_fragment)
+    manager.add(sr_arrays_fragment)
+    manager.add(sr_devices_fragment)
+
+    assert manager["BPM_C04*"] == ["BPM_C04-01", "BPM_C04-02"]
+    assert manager.HCORR["type"] == "pyaml.arrays.magnet"
+    assert manager.simulators == ["design"]

--- a/tests/test_configuration_manager.py
+++ b/tests/test_configuration_manager.py
@@ -212,11 +212,44 @@ def test_configuration_manager_rejects_duplicate_names(
         manager.add({"simulators": [simulator_fragment_factory("design")]})
 
 
-def test_configuration_manager_rejects_rest_source_explicitly():
+def test_configuration_manager_adds_remote_source_with_relative_includes(http_config_server):
+    manager = ConfigurationManager()
+    routes = {
+        "/configs/base.yaml": """
+type: pyaml.accelerator
+facility: Remote Facility
+machine: remote_ring
+energy: 3000000000.0
+data_folder: remote-data
+description: Loaded over HTTP
+simulators: fragments/simulators.json
+devices: []
+""",
+        "/configs/fragments/simulators.json": """
+[
+  {
+    "type": "pyaml.lattice.simulator",
+    "name": "design",
+    "lattice": "../lattices/ebs.mat"
+  }
+]
+""",
+    }
+
+    with http_config_server(routes) as base_url:
+        manager.add(f"{base_url}/configs/base.yaml")
+
+        assert manager.settings()["facility"] == "Remote Facility"
+        assert manager.keys("simulators") == ["design"]
+        assert manager.get("simulators", "design")["lattice"] == f"{base_url}/configs/lattices/ebs.mat"
+
+
+def test_configuration_manager_reports_remote_fetch_failures(http_config_server):
     manager = ConfigurationManager()
 
-    with pytest.raises(PyAMLConfigException, match="REST configuration sources are not implemented yet"):
-        manager.add("https://example.org/config")
+    with http_config_server({}) as base_url:
+        with pytest.raises(PyAMLConfigException, match="Unable to fetch remote configuration"):
+            manager.add(f"{base_url}/missing.yaml")
 
 
 def test_configuration_manager_repr_is_yellow_pages_like(

--- a/tests/test_configuration_manager.py
+++ b/tests/test_configuration_manager.py
@@ -13,7 +13,7 @@ def test_configuration_manager_add_from_dict(
 ):
     manager = ConfigurationManager()
 
-    manager.add(
+    result = manager.add(
         {
             "facility": "Dict Facility",
             "machine": "dict_ring",
@@ -25,6 +25,7 @@ def test_configuration_manager_add_from_dict(
         source_name="dict-fixture",
     )
 
+    assert result is None
     assert manager.categories() == ["simulators"]
     assert manager.keys() == ["design"]
     assert manager.keys("simulators") == ["design"]
@@ -56,8 +57,9 @@ def test_configuration_manager_remove_named_entry(
     manager.add(config_manager_base_config)
     manager.add({"simulators": [simulator_fragment_factory("tracking")]})
 
-    manager.remove("simulators", "tracking")
+    result = manager.remove("simulators", "tracking")
 
+    assert result is None
     assert manager.keys("simulators") == ["design"]
     assert not manager.has("simulators", "tracking")
 
@@ -69,7 +71,7 @@ def test_configuration_manager_replace_named_entry(
     manager = ConfigurationManager()
     manager.add(config_manager_base_config)
 
-    manager.replace(
+    result = manager.replace(
         "simulators",
         {
             "type": "pyaml.lattice.simulator",
@@ -79,6 +81,7 @@ def test_configuration_manager_replace_named_entry(
         },
     )
 
+    assert result is None
     assert manager.get("simulators", "design")["description"] == "Replaced simulator"
 
 
@@ -90,15 +93,42 @@ def test_configuration_manager_clear_category_and_settings(
     manager.add(config_manager_base_config)
     manager.add({"simulators": [simulator_fragment_factory("tracking")]})
 
-    manager.clear("simulators")
+    result = manager.clear("simulators")
 
+    assert result is None
     assert manager.keys("simulators") == []
     assert manager.categories() == []
     assert manager.settings()["facility"] == "Test Facility"
 
-    manager.clear()
+    result = manager.clear()
 
+    assert result is None
     assert manager.to_dict() == {"type": "pyaml.accelerator"}
+
+
+def test_configuration_manager_settings_follow_accelerator_config_model_order():
+    manager = ConfigurationManager()
+    manager.add(
+        {
+            "facility": "Test Facility",
+            "machine": "ring",
+            "energy": 3.0e9,
+            "alphac": 1.0e-4,
+            "data_folder": "data",
+            "description": "Ordered settings",
+            "devices": [],
+        }
+    )
+
+    assert list(manager.settings()) == [
+        "type",
+        "facility",
+        "machine",
+        "energy",
+        "alphac",
+        "data_folder",
+        "description",
+    ]
 
 
 def test_configuration_manager_to_dict_snapshot_can_be_reloaded(
@@ -178,7 +208,7 @@ def test_configuration_manager_repr_is_yellow_pages_like(
     assert "Devices:" in output
     assert "live (tango.pyaml.controlsystem) source=config_manager_sr_base.yaml" in output
     assert "design (pyaml.lattice.simulator) source=config_manager_sr_base.yaml" in output
-    assert "HCORR (pyaml.arrays.magnet) selectors=1 source=config_manager_sr_arrays.yaml" in output
+    assert "HCORR (pyaml.arrays.magnet) patterns=1 source=config_manager_sr_arrays.yaml" in output
     assert "BPM_C04-01 (pyaml.bpm.bpm) source=config_manager_sr_devices.yaml" in output
     assert "    ." in output
 

--- a/tests/test_configuration_manager.py
+++ b/tests/test_configuration_manager.py
@@ -162,6 +162,37 @@ def test_configuration_manager_build_explicitly(
     assert accelerator.simulators()["tracking"].name() == "tracking"
 
 
+def test_configuration_manager_accumulates_multiple_device_fragments(
+    sr_base_fragment,
+    sr_devices_fragment,
+    tune_monitor_devices_fragment,
+):
+    manager = ConfigurationManager()
+    manager.add(sr_base_fragment)
+    manager.add(sr_devices_fragment)
+    manager.add(tune_monitor_devices_fragment)
+
+    assert manager.categories() == ["controls", "simulators", "devices"]
+    assert manager.keys("devices") == [
+        "QF1A-C01",
+        "SH1A-C01",
+        "SH1A-C02",
+        "BPM_C04-01",
+        "BPM_C04-02",
+        "BETATRON_TUNE",
+    ]
+    assert manager.has("devices", "QF1A-C01")
+    assert manager.has("devices", "SH1A-C01")
+    assert manager.has("devices", "SH1A-C02")
+    assert manager.has("devices", "BPM_C04-01")
+    assert manager.has("devices", "BPM_C04-02")
+    assert manager.has("devices", "BETATRON_TUNE")
+    assert manager.get("devices", "QF1A-C01")["type"] == "pyaml.magnet.quadrupole"
+    assert manager.get("devices", "SH1A-C01")["type"] == "pyaml.magnet.cfm_magnet"
+    assert manager.get("devices", "BPM_C04-01")["type"] == "pyaml.bpm.bpm"
+    assert manager.get("devices", "BETATRON_TUNE")["type"] == "pyaml.diagnostics.tune_monitor"
+
+
 def test_accelerator_load_stays_compatible(config_manager_base_config):
     accelerator = Accelerator.load(config_manager_base_config)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,6 +3,7 @@ import pytest
 from pyaml.accelerator import Accelerator
 from pyaml.arrays.magnet_array import MagnetArray
 from pyaml.common.exception import PyAMLConfigException, PyAMLException
+from pyaml.configuration import ConfigurationManager
 
 
 @pytest.mark.parametrize(
@@ -23,6 +24,7 @@ def test_tune(install_test_package):
         ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_3.yaml")
     assert "Configuration entry 'BPM_C04-06' is duplicated inside category 'devices'" in str(exc)
     assert "bad_conf_duplicate_3.yaml" in str(exc)
+    assert "line 58, column 3" in str(exc)
 
     with pytest.raises(PyAMLConfigException) as exc:
         ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_4.yaml")
@@ -42,3 +44,129 @@ def test_tune(install_test_package):
     with pytest.raises(PyAMLException) as exc:
         m2 = sr.design.get_bpm("QF1A-C05XX")
     assert "BPM QF1A-C05XX not defined" in str(exc)
+
+
+def test_duplicate_error_reports_source_line_and_column_across_files(tmp_path):
+    devices_a = tmp_path / "devices_a.yaml"
+    devices_a.write_text(
+        "- type: test.device\n  name: BPM_DUPLICATE\n",
+        encoding="utf-8",
+    )
+    devices_b = tmp_path / "devices_b.yaml"
+    devices_b.write_text(
+        "- type: test.device\n  name: BPM_UNIQUE\n- type: test.device\n  name: BPM_DUPLICATE\n",
+        encoding="utf-8",
+    )
+    root = tmp_path / "root.yaml"
+    root.write_text(
+        "type: pyaml.accelerator\ndevices:\n  - devices_a.yaml\n  - devices_b.yaml\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PyAMLConfigException) as exc:
+        Accelerator.load(str(root))
+
+    message = str(exc.value)
+    assert "Configuration entry 'BPM_DUPLICATE' is duplicated inside category 'devices'" in message
+    assert f"source '{devices_a}' at line 1, column 3" in message
+    assert f"source '{devices_b}' at line 3, column 3" in message
+
+
+def test_malformed_local_included_yaml_reports_source_line_and_column(tmp_path):
+    broken_devices = tmp_path / "broken_devices.yaml"
+    broken_devices.write_text(
+        "- type: pyaml.bpm.bpm\n  name: BPM_BROKEN\n  model:\n    type: [oops\n",
+        encoding="utf-8",
+    )
+    root = tmp_path / "root.yaml"
+    root.write_text(
+        "type: pyaml.accelerator\n"
+        "facility: ESRF\n"
+        "machine: sr\n"
+        "energy: 6e9\n"
+        "data_folder: /data/store\n"
+        "devices: broken_devices.yaml\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PyAMLException) as exc:
+        Accelerator.load(str(root))
+
+    message = str(exc.value)
+    assert str(broken_devices) in message
+    assert "line 4, column 11" in message
+
+
+def test_truncated_local_included_json_reports_source_and_position(tmp_path):
+    broken_devices = tmp_path / "broken_devices.json"
+    broken_devices.write_text(
+        '{"type": "pyaml.bpm.bpm", "name": "BPM_BROKEN", "model": ',
+        encoding="utf-8",
+    )
+    root = tmp_path / "root.yaml"
+    root.write_text(
+        "type: pyaml.accelerator\n"
+        "facility: ESRF\n"
+        "machine: sr\n"
+        "energy: 6e9\n"
+        "data_folder: /data/store\n"
+        "devices: broken_devices.json\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PyAMLException) as exc:
+        Accelerator.load(str(root))
+
+    message = str(exc.value)
+    assert str(broken_devices) in message
+    assert "line 1 column" in message
+
+
+def test_malformed_remote_included_yaml_reports_source_line_and_column(http_config_server):
+    routes = {
+        "/configs/root.yaml": (
+            "type: pyaml.accelerator\n"
+            "facility: ESRF\n"
+            "machine: sr\n"
+            "energy: 6000000000.0\n"
+            "data_folder: /data/store\n"
+            "devices: fragments/broken_devices.yaml\n"
+        ),
+        "/configs/fragments/broken_devices.yaml": (
+            "- type: pyaml.bpm.bpm\n  name: BPM_BROKEN\n  model:\n    type: [oops\n"
+        ),
+    }
+
+    with http_config_server(routes) as base_url:
+        with pytest.raises(PyAMLConfigException) as exc:
+            ConfigurationManager().add(f"{base_url}/configs/root.yaml")
+
+    message = str(exc.value)
+    assert f"{base_url}/configs/fragments/broken_devices.yaml" in message
+    assert "line 4, column 11" in message
+
+
+def test_truncated_remote_included_json_reports_source_and_position(http_config_server):
+    routes = {
+        "/configs/root.yaml": (
+            "type: pyaml.accelerator\n"
+            "facility: ESRF\n"
+            "machine: sr\n"
+            "energy: 6000000000.0\n"
+            "data_folder: /data/store\n"
+            "devices: fragments/broken_devices.json\n"
+        ),
+        "/configs/fragments/broken_devices.json": (
+            '{"type": "pyaml.bpm.bpm", "name": "BPM_BROKEN", "model": ',
+            "application/json",
+            200,
+        ),
+    }
+
+    with http_config_server(routes) as base_url:
+        with pytest.raises(PyAMLConfigException) as exc:
+            ConfigurationManager().add(f"{base_url}/configs/root.yaml")
+
+    message = str(exc.value)
+    assert f"{base_url}/configs/fragments/broken_devices.json" in message
+    assert "line 1 column" in message

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -21,8 +21,8 @@ def test_tune(install_test_package):
 
     with pytest.raises(PyAMLConfigException) as exc:
         ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_3.yaml")
-    assert "element BPM_C04-06 already defined" in str(exc)
-    assert "line 58, column 3" in str(exc)
+    assert "Configuration entry 'BPM_C04-06' is duplicated inside category 'devices'" in str(exc)
+    assert "bad_conf_duplicate_3.yaml" in str(exc)
 
     with pytest.raises(PyAMLConfigException) as exc:
         ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_4.yaml")
@@ -33,10 +33,7 @@ def test_tune(install_test_package):
     m2 = sr.design.get_magnet("QF1A-C05")
     with pytest.raises(PyAMLException) as exc:
         ma = MagnetArray("Test", [m1, m2])
-    assert (
-        "MagnetArray Test: All elements must be attached to the same instance"
-        in str(exc)
-    )
+    assert "MagnetArray Test: All elements must be attached to the same instance" in str(exc)
 
     with pytest.raises(PyAMLException) as exc:
         m2 = sr.design.get_magnet("QF1A-C05XX")

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -2,7 +2,9 @@ import pytest
 
 from pyaml import PyAMLConfigException, PyAMLException
 from pyaml.accelerator import Accelerator
+from pyaml.configuration import get_root_folder, set_root_folder
 from pyaml.configuration.factory import Factory
+from pyaml.configuration.fileloader import load
 from tests.conftest import MockElement
 
 
@@ -29,8 +31,14 @@ def test_factory_with_custom_strategy():
     ],
 )
 def test_error_location(test_file):
-    with pytest.raises(PyAMLConfigException) as exc:
-        ml: Accelerator = Accelerator.load(test_file)
+    previous_root = get_root_folder()
+    try:
+        with pytest.raises(PyAMLConfigException) as exc:
+            set_root_folder("tests/config")
+            cfg = load("bad_conf.yml")
+            Factory.depth_first_build(cfg, False)
+    finally:
+        set_root_folder(previous_root)
     print(str(exc.value))
     test_file_names = test_file.split("/")
     test_file_name = test_file_names[len(test_file_names) - 1]

--- a/tests/test_tune_monitor.py
+++ b/tests/test_tune_monitor.py
@@ -1,11 +1,13 @@
 import pytest
 
-from pyaml.accelerator import Accelerator
 
-
-def test_simulator_tune_monitor():
-    sr: Accelerator = Accelerator.load(
-        "tests/config/tune_monitor.yaml", ignore_external=True
+def test_simulator_tune_monitor(
+    accelerator_from_fragments,
+    tune_monitor_configuration_fragments,
+):
+    sr = accelerator_from_fragments(
+        *tune_monitor_configuration_fragments,
+        ignore_external=True,
     )
     sr.design.get_lattice().disable_6d()
     tune_monitor = sr.design.get_betatron_tune_monitor("BETATRON_TUNE")
@@ -18,8 +20,14 @@ def test_simulator_tune_monitor():
     [{"name": "tango-pyaml", "path": "tests/dummy_cs/tango-pyaml"}],
     indirect=True,
 )
-def test_controlsystem_tune_monitor(install_test_package):
-    sr: Accelerator = Accelerator.load("tests/config/tune_monitor.yaml")
+def test_controlsystem_tune_monitor(
+    install_test_package,
+    accelerator_from_fragments,
+    tune_monitor_configuration_fragments,
+):
+    sr = accelerator_from_fragments(
+        *tune_monitor_configuration_fragments,
+    )
     tune_monitor = sr.live.get_betatron_tune_monitor("BETATRON_TUNE")
     assert tune_monitor.tune.get()[0] == 0.0
     assert tune_monitor.tune.get()[1] == 0.0


### PR DESCRIPTION
## Description

Add a `ConfigurationManager` that can aggregate accelerator-root YAML/JSON/dict fragments before building an `Accelerator`. This makes incremental configuration assembly explicit, keeps `Accelerator.load()` compatible for full accelerator configs, exposes inspection/query helpers for merged configuration state, and now supports REST-backed YAML/JSON sources with relative includes resolved from the base URL.

## Related Issue

This project only accepts pull requests related to open issues. If suggesting a new feature or change, please discuss it in an issue first.

- Fixes #228

Features/issues described there are:
- [x] new feature: introduced `pyaml.configuration.ConfigurationManager` to add, inspect, query, replace, remove, clear, snapshot and build accelerator configuration fragments incrementally because the previous flow only supported loading a single full accelerator file.
- [x] bugfix: updated `Accelerator.load()` to validate that the root config is `pyaml.accelerator` and raise a clearer error for sub-element roots because the new configuration flow now distinguishes full accelerator builds from direct factory usage.
- [x] new feature: documented and exported `ConfigurationManager` in `pyaml.configuration` and generated API docs, including exploratory special members, because the new API is intended for direct public use.
- [x] new feature: added REST configuration loading through a dedicated fetcher module, including recursive remote YAML/JSON includes and relative path resolution from the remote base URL, because configuration fragments may now be hosted remotely instead of only on the local filesystem.

## Changes to existing functionality

Describe the changes that had to be made to an existing functionality (if they were made)

- [x] `Accelerator.load()` now builds through `ConfigurationManager.add(...).build(...)` instead of calling the file loader directly, while preserving support for standard accelerator files.
- [x] `Accelerator.load()` no longer assumes a local filesystem path up front, so full accelerator configurations can now be loaded from local files or `http`/`https` URLs through the same manager-based flow.
- [x] `ConfigurationManager` now delegates remote fetching/parsing to `pyaml.configuration.restfetcher` rather than embedding HTTP logic in `manager.py`, keeping network concerns isolated from merge logic.
- [x] Test fixtures no longer install temporary test packages with `pip`; they now expose package roots through `sys.path` and purge imported modules between tests, which avoids editable/install side effects during the test suite.
- [x] Several tests that previously loaded monolithic YAML files now build accelerators from multiple fragments, proving the incremental configuration path on arrays, devices and tune-monitor use cases.

## Testing
 The following tests (compatible with pytest) were added:
 - [x] `tests/test_configuration_manager.py`
 - [x] `tests/test_accelerator_load.py`
 - [x] Extended regression coverage in `tests/test_arrays_ops.py`, `tests/test_errors.py`, `tests/test_factory.py` and `tests/test_tune_monitor.py`
 - [x] Added local HTTP-server fixtures in `tests/conftest.py` to exercise remote configuration loading and base-URL include resolution
 - [x] Verified locally with `pytest tests/test_configuration_manager.py tests/test_accelerator_load.py` (`17 passed`)

## Verify that your checklist complies with the project
- [x] New and existing unit tests pass locally
- [x] Tests were added to prove that all features/changes are effective
- [x] The code is commented where appropriate
- [x] Any existing features are not broken (unless there is an explicit change to an existing functionality)
