### PR TITLE
Removed factory custom strategy

### DIFF
--- a/pyaml/configuration/factory.py
+++ b/pyaml/configuration/factory.py
@@ -10,16 +10,6 @@ from ..common.exception import PyAMLConfigException
 from .unbound_element import UnboundElement
 
 
-class BuildStrategy:
-    def can_handle(self, module: object, config_dict: dict) -> bool:
-        """Return True if this strategy can handle the module/config."""
-        raise NotImplementedError
-
-    def build(self, module: object, config_dict: dict):
-        """Build the object according to custom logic."""
-        raise NotImplementedError
-
-
 class PyAMLFactory:
     """Singleton factory to build PyAML elements with future compatibility logic."""
 
@@ -37,14 +27,6 @@ class PyAMLFactory:
                 cls._instance._elements = {}
                 cls._instance._strategies = []
             return cls._instance
-
-    def register_strategy(self, strategy: BuildStrategy):
-        """Register a plugin-based strategy for object creation."""
-        self._strategies.append(strategy)
-
-    def remove_strategy(self, strategy: BuildStrategy):
-        """Register a plugin-based strategy for object creation."""
-        self._strategies.remove(strategy)
 
     def handle_validation_error(self, e, type_str: str, location_str: str, field_locations: dict):
         # Handle pydantic errors
@@ -97,16 +79,6 @@ class PyAMLFactory:
                 ) from None
             else:
                 return None
-
-        # Try plugin strategies first
-        for strategy in self._strategies:
-            try:
-                if strategy.can_handle(module, d):
-                    obj = strategy.build(module, d)
-                    self.register_element(obj)
-                    return obj
-            except Exception as e:
-                raise PyAMLConfigException(f"Custom strategy failed {location_str}") from e
 
         # Get the object class name
         if class_str is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ import pytest
 from pydantic import BaseModel
 
 from pyaml.configuration import ConfigurationManager
-from pyaml.configuration.factory import BuildStrategy, Factory
+from pyaml.configuration.factory import Factory
 from pyaml.control.readback_value import Value
 
 
@@ -428,18 +428,6 @@ mock_module.PYAMLCLASS = "MockElement"
 mock_module.MockElement = MockElement
 
 
-# ────────────── Custom strategy ──────────────
-
-
-class MockStrategy(BuildStrategy):
-    def can_handle(self, module, config_dict):
-        return config_dict.get("custom") is True
-
-    def build(self, module, config_dict):
-        name = config_dict.get("name", "default")
-        return MockElement(config=MockConfig(name=f"custom_{name}"))
-
-
 # ────────────── Pytest fixtures ──────────────
 
 
@@ -457,15 +445,6 @@ def clear_factory_registry():
     Factory.clear()
     yield
     Factory.clear()
-
-
-@pytest.fixture(autouse=True)
-def register_mock_strategy():
-    """Register and unregister mock build strategy."""
-    strategy = MockStrategy()
-    Factory.register_strategy(strategy)
-    yield
-    Factory.remove_strategy(strategy)
 
 
 # -----------------------

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -16,14 +16,6 @@ def test_factory_build_default():
     assert obj.name == "simple"
 
 
-def test_factory_with_custom_strategy():
-    """Test that custom BuildStrategy overrides default logic."""
-    data = {"type": "mock_module", "name": "injected", "custom": True}
-    obj = Factory.depth_first_build(data, False)
-    assert isinstance(obj, MockElement)
-    assert obj.name == "custom_injected"
-
-
 @pytest.mark.parametrize(
     "test_file",
     [


### PR DESCRIPTION
This PR removes factory custom build strategy which is not a suitable injection.
This strategy can potentially override an internal module and make pyaml difficult to debug.
