### PR TITLE
Fix private peer access using the public property

### DIFF
--- a/pyaml/diagnostics/tune_monitor.py
+++ b/pyaml/diagnostics/tune_monitor.py
@@ -91,7 +91,7 @@ class BetatronTuneMonitor(Element, ABetatronTuneMonitor):
                 rf_name = self.parent._cfg.rf_plant_name
                 if h is not None and rf_name is not None:
                     tune = self.parent.tune.get()
-                    rf = self.parent._peer.get_rf_plant(rf_name)
+                    rf = self.parent.peer.get_rf_plant(rf_name)
                     freq = rf.frequency.get()
                     return tune * freq / h
 

--- a/pyaml/tuning_tools/orbit.py
+++ b/pyaml/tuning_tools/orbit.py
@@ -148,7 +148,7 @@ class Orbit(TuningTool):
             raise PyAMLException(f"{self.get_name()} does not have a response_matrix.")
 
         interface = pySCInterface(
-            element_holder=self._peer,
+            element_holder=self.peer,
             bpm_array_name=self.bpm_array_name,
         )
 
@@ -294,11 +294,11 @@ class Orbit(TuningTool):
         return self._pySC_response_matrix.rf_weight
 
     def post_init(self):
-        self._hcorr = self._peer.get_magnets(self._cfg.hcorr_array_name)
-        self._vcorr = self._peer.get_magnets(self._cfg.vcorr_array_name)
+        self._hcorr = self.peer.get_magnets(self._cfg.hcorr_array_name)
+        self._vcorr = self.peer.get_magnets(self._cfg.vcorr_array_name)
         hvElts = []
         hvElts.extend(self._hcorr)
         hvElts.extend(self._vcorr)
         self._hvcorr = MagnetArray("", hvElts)
         if self._cfg.rf_plant_name is not None:
-            self._rf_plant = self._peer.get_rf_plant(self._cfg.rf_plant_name)
+            self._rf_plant = self.peer.get_rf_plant(self._cfg.rf_plant_name)

--- a/pyaml/tuning_tools/tune.py
+++ b/pyaml/tuning_tools/tune.py
@@ -97,12 +97,12 @@ class Tune(TuningTool):
     @property
     def _tm(self) -> "BetatronTuneMonitor":
         self.check_peer()
-        return self._peer.get_betatron_tune_monitor(self._cfg.betatron_tune_name)
+        return self.peer.get_betatron_tune_monitor(self._cfg.betatron_tune_name)
 
     @property
     def _quads(self) -> "MagnetArray":
         self.check_peer()
-        return self._peer.get_magnets(self._cfg.quad_array_name)
+        return self.peer.get_magnets(self._cfg.quad_array_name)
 
     def get(self):
         """


### PR DESCRIPTION
This PR fix access to peer using the public property.
Note: All access to the private `_peer` field are reserved to internal attachment process.