### PR TITLE
Fix broken methods in `LinearSerializedMagnetModel`

### DIFF
--- a/pyaml/magnet/linear_serialized_model.py
+++ b/pyaml/magnet/linear_serialized_model.py
@@ -147,23 +147,21 @@ class LinearSerializedMagnetModel(MagnetModel):
         return self.__sub_models[index]
 
     def compute_hardware_values(self, strengths: np.array) -> np.array:
-        return np.array(
-            [model.compute_hardware_values([strength]) for strength, model in zip(strengths, self.__sub_models, strict=True)]
-        )
+        currents = [model.compute_hardware_values([s])[0] for s, model in zip(strengths, self.__sub_models, strict=True)]
+        return np.array([np.mean(currents)])
 
     def compute_strengths(self, currents: np.array) -> np.array:
-        return np.array(
-            [model.compute_strengths([current]) for current, model in zip(currents, self.__sub_models, strict=True)]
-        )
+        current = currents[0]
+        return np.array([model.compute_strengths([current])[0] for model in self.__sub_models])
 
     def get_strength_units(self) -> list[str]:
-        return self._cfg.units
+        return [self._cfg.unit] * self.__nbMagnets
 
     def get_hardware_units(self) -> list[str]:
-        return [p.unit() for p in self._cfg.__sub_models]
+        return [self.__sub_models[0].get_hardware_units()[0]]
 
     def get_devices(self) -> list[DeviceAccess]:
-        return self._cfg.powerconverters
+        return [self._cfg.powerconverter]
 
     def set_magnet_rigidity(self, brho: np.double):
         self.__brho = brho

--- a/pyaml/magnet/serialized_magnet.py
+++ b/pyaml/magnet/serialized_magnet.py
@@ -171,7 +171,4 @@ class SerializedMagnets(Element):
         return __pyaml_repr__(self)
 
     def get_devices(self) -> list[DeviceAccess]:
-        if isinstance(self.model.powerconverter, list):
-            return self.model.powerconverter
-        else:
-            return [self._cfg.powerconverter]
+        return self.model.get_devices()

--- a/tests/test_serialized_magnets.py
+++ b/tests/test_serialized_magnets.py
@@ -154,6 +154,27 @@ def test_tune(sr_file):
     assert np.abs(diffTune[1] - 0.05) < 1e-3
 
 
+@pytest.mark.parametrize(
+    "sr_file",
+    [
+        "tests/config/sr_serialized_magnets.yaml",
+    ],
+)
+def test_get_devices(sr_file):
+    sr: Accelerator = Accelerator.load(sr_file, use_fast_loader=True, ignore_external=True)
+    sm: SerializedMagnets = sr.design.get_serialized_magnet("QF1A")
+
+    devices = sm.get_devices()
+
+    # Serialized magnets share a single power converter: exactly 1 device
+    assert len(devices) == 1
+    # Strength and hardware computation must remain consistent after the fix
+    initial_strength = sm.strength.get()
+    sm.strength.set(initial_strength * 1.01)
+    assert abs(sm.strength.get() - initial_strength * 1.01) < 1e-3
+    sm.strength.set(initial_strength)
+
+
 def get_strengths_from_lattice(sr: Accelerator, sm: SerializedMagnets) -> list:
     ring = sr.design.get_lattice()
     strs = []


### PR DESCRIPTION
## Summary

- Fix four `AttributeError` bugs in `LinearSerializedMagnetModel` caused by wrong field names (`powerconverters`, `units`) and misplaced attribute access (`_cfg.__sub_models`)
- Rework compute methods to reflect physical reality: one power converter drives N serialized magnets in series
- `get_devices()` now returns a single device; `compute_strengths` accepts one current and returns N strengths; `compute_hardware_values` accepts N strengths and returns one current

Closes #253 

## Test plan

- [x] All 145 existing tests pass
- [x] `test_get_devices` verifies `len(get_devices()) == 1` and that strength set/get remains consistent
