### PR TITLE
Change name of get_peer_name to attached_to in Element.

### DIFF
--- a/pyaml/common/element.py
+++ b/pyaml/common/element.py
@@ -16,7 +16,7 @@ def __pyaml_repr__(obj):
         if isinstance(obj, Element):
             return repr(obj._cfg).replace(
                 "ConfigModel(",
-                obj.__class__.__name__ + "(peer='" + obj.get_peer_name() + "', ",
+                obj.__class__.__name__ + "(peer='" + obj.attached_to() + "', ",
             )
         else:
             # no peer

--- a/pyaml/common/element.py
+++ b/pyaml/common/element.py
@@ -124,9 +124,9 @@ class Element(object):
         """
         return self._peer
 
-    def get_peer_name(self) -> str:
+    def attached_to(self) -> str:
         """
-        Returns a string representation of peer simulator or control system
+        Returns a string of which peer the element is attached to.
         """
         return "None" if self._peer is None else f"{self._peer.__class__.__name__}:{self._peer.name()}"
 

--- a/pyaml/magnet/magnet.py
+++ b/pyaml/magnet/magnet.py
@@ -116,7 +116,7 @@ class Magnet(Element):
     def __repr__(self):
         return "%s(peer='%s', name='%s', model_name='%s', magnet_model=%s)" % (
             self.__class__.__name__,
-            self.get_peer_name(),
+            self.attached_to(),
             self.get_name(),
             self.__modelName,
             repr(self.__model),

--- a/pyaml/tuning_tools/measurement_tool.py
+++ b/pyaml/tuning_tools/measurement_tool.py
@@ -153,7 +153,7 @@ class MeasurementTool(Element, metaclass=ABCMeta):
         ok = True
         if self._callback is not None:
             # Add source and peer
-            cb_data["mode"] = f"{self.get_peer_name()}"
+            cb_data["mode"] = f"{self.attached_to()}"
             cb_data["source"] = self
             ok = self._callback(action, cb_data)
         if not ok and raiseException:


### PR DESCRIPTION
I suggest to change the function name `get_peer_name` in Element to `attached_to` to make it easier for the users to understand what this function does and make it clearer that it returns something which is different than doing peer.name and that's why there is a specific function for it.