### PR TITLE
Remove empty file.

### DIFF
--- a/pyaml/apidoc/gen_api.py
+++ b/pyaml/apidoc/gen_api.py
@@ -50,7 +50,6 @@ modules = [
     "pyaml.external.pySC_interface",
     "pyaml.lattice.abstract_impl",
     "pyaml.lattice.attribute_linker",
-    "pyaml.lattice.element",
     "pyaml.lattice.lattice_elements_linker",
     "pyaml.lattice.polynom_info",
     "pyaml.lattice.simulator",


### PR DESCRIPTION
The file element.py in lattice is empty so it can be removed.