### PR TITLE
Adapting the catalogs and dummy CS to recent catalog evolutions

### DIFF
--- a/examples/SOLEIL_examples/catalogs.yaml
+++ b/examples/SOLEIL_examples/catalogs.yaml
@@ -1,2163 +1,2184 @@
-- type: tango.pyaml.static_catalog
-  name: bpm-catalog
-  entries:
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.08/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.08/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.08/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.08/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.09/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.09/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.09/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.09/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.10/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.10/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-AR/DG-EPOS/BPM.10/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-AR/DG-EPOS/BPM.10/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN02-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN02-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.08/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.08/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.08/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.08/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.09/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.09/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.09/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.09/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.10/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.10/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN03-AR/DG-EPOS/BPM.10/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN03-AR/DG-EPOS/BPM.10/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN04-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN04-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.08/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.08/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.08/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.08/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.09/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.09/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.09/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.09/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.10/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.10/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN05-AR/DG-EPOS/BPM.10/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN05-AR/DG-EPOS/BPM.10/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-SD/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-SD/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-SD/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-SD/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-SD/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-SD/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-SD/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-SD/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.08/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.08/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.08/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.08/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.09/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.09/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.09/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.09/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.10/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.10/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.10/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.10/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.11/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.11/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.11/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.11/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.12/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.12/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN06-AR/DG-EPOS/BPM.12/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN06-AR/DG-EPOS/BPM.12/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN07-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN07-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.08/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.08/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.08/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.08/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.09/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.09/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.09/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.09/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.10/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.10/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN08-AR/DG-EPOS/BPM.10/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN08-AR/DG-EPOS/BPM.10/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN09-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN09-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.08/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.08/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.08/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.08/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.09/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.09/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.09/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.09/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.10/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.10/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN10-AR/DG-EPOS/BPM.10/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN10-AR/DG-EPOS/BPM.10/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.08/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.08/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.08/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.08/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.09/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.09/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.09/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.09/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.10/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.10/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN11-AR/DG-EPOS/BPM.10/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN11-AR/DG-EPOS/BPM.10/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN12-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN12-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.08/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.08/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.08/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.08/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.09/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.09/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.09/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.09/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.10/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.10/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN13-AR/DG-EPOS/BPM.10/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN13-AR/DG-EPOS/BPM.10/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN14-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN14-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.08/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.08/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.08/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.08/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.09/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.09/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.09/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.09/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.10/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.10/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN15-AR/DG-EPOS/BPM.10/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN15-AR/DG-EPOS/BPM.10/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-SD/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-SD/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-SD/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-SD/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-SD/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-SD/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-SD/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-SD/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.08/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.08/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.08/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.08/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.09/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.09/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.09/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.09/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.10/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.10/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.10/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.10/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.11/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.11/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.11/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.11/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.12/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.12/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN16-AR/DG-EPOS/BPM.12/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN16-AR/DG-EPOS/BPM.12/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN17-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN17-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.08/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.08/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.08/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.08/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.09/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.09/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.09/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.09/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.10/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.10/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN18-AR/DG-EPOS/BPM.10/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN18-AR/DG-EPOS/BPM.10/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN19-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN19-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-SD/DG-EPOS/BPM.02/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-SD/DG-EPOS/BPM.02/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-SD/DG-EPOS/BPM.02/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-SD/DG-EPOS/BPM.02/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.03/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.03/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.03/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.03/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.04/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.04/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.04/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.04/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.05/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.05/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.05/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.05/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.06/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.06/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.06/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.06/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.07/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.07/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.07/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.07/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.08/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.08/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.08/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.08/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.09/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.09/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.09/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.09/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.10/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.10/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN20-AR/DG-EPOS/BPM.10/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN20-AR/DG-EPOS/BPM.10/y_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-SD/DG-EPOS/BPM.01/x_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-SD/DG-EPOS/BPM.01/x_pos
-      unit: mm
-  - type: tango.pyaml.static_catalog_entry
-    key: AN01-SD/DG-EPOS/BPM.01/y_pos
-    device:
-      type: tango.pyaml.attribute_read_only
-      attribute: AN01-SD/DG-EPOS/BPM.01/y_pos
-      unit: mm
+type: tango.pyaml.static_catalog
+entries:
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.08/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.08/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.08/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.08/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.09/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.09/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.09/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.09/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.10/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.10/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-AR/DG-EPOS/BPM.10/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-AR/DG-EPOS/BPM.10/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN02-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN02-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.08/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.08/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.08/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.08/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.09/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.09/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.09/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.09/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.10/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.10/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN03-AR/DG-EPOS/BPM.10/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN03-AR/DG-EPOS/BPM.10/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN04-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN04-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.08/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.08/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.08/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.08/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.09/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.09/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.09/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.09/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.10/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.10/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN05-AR/DG-EPOS/BPM.10/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN05-AR/DG-EPOS/BPM.10/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-SD/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-SD/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-SD/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-SD/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-SD/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-SD/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-SD/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-SD/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.08/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.08/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.08/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.08/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.09/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.09/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.09/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.09/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.10/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.10/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.10/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.10/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.11/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.11/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.11/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.11/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.12/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.12/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN06-AR/DG-EPOS/BPM.12/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN06-AR/DG-EPOS/BPM.12/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN07-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN07-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.08/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.08/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.08/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.08/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.09/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.09/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.09/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.09/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.10/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.10/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN08-AR/DG-EPOS/BPM.10/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN08-AR/DG-EPOS/BPM.10/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN09-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN09-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.08/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.08/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.08/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.08/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.09/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.09/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.09/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.09/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.10/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.10/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN10-AR/DG-EPOS/BPM.10/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN10-AR/DG-EPOS/BPM.10/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.08/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.08/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.08/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.08/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.09/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.09/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.09/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.09/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.10/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.10/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN11-AR/DG-EPOS/BPM.10/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN11-AR/DG-EPOS/BPM.10/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN12-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN12-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.08/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.08/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.08/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.08/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.09/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.09/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.09/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.09/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.10/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.10/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN13-AR/DG-EPOS/BPM.10/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN13-AR/DG-EPOS/BPM.10/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN14-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN14-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.08/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.08/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.08/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.08/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.09/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.09/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.09/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.09/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.10/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.10/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN15-AR/DG-EPOS/BPM.10/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN15-AR/DG-EPOS/BPM.10/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-SD/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-SD/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-SD/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-SD/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-SD/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-SD/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-SD/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-SD/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.08/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.08/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.08/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.08/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.09/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.09/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.09/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.09/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.10/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.10/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.10/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.10/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.11/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.11/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.11/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.11/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.12/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.12/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN16-AR/DG-EPOS/BPM.12/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN16-AR/DG-EPOS/BPM.12/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN17-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN17-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.08/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.08/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.08/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.08/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.09/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.09/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.09/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.09/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.10/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.10/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN18-AR/DG-EPOS/BPM.10/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN18-AR/DG-EPOS/BPM.10/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN19-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN19-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-SD/DG-EPOS/BPM.02/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-SD/DG-EPOS/BPM.02/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-SD/DG-EPOS/BPM.02/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-SD/DG-EPOS/BPM.02/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.03/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.03/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.03/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.03/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.04/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.04/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.04/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.04/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.05/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.05/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.05/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.05/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.06/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.06/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.06/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.06/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.07/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.07/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.07/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.07/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.08/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.08/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.08/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.08/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.09/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.09/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.09/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.09/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.10/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.10/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN20-AR/DG-EPOS/BPM.10/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN20-AR/DG-EPOS/BPM.10/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-SD/DG-EPOS/BPM.01/x_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-SD/DG-EPOS/BPM.01/x_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: AN01-SD/DG-EPOS/BPM.01/y_pos
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: AN01-SD/DG-EPOS/BPM.01/y_pos
+    unit: mm
+- type: tango.pyaml.static_catalog_entry
+  key: simulator/ringsimulator/ringsimulator/RfFrequency
+  device:
+    type: tango.pyaml.attribute
+    attribute: simulator/ringsimulator/ringsimulator/RfFrequency
+    unit: Hz
+- type: tango.pyaml.static_catalog_entry
+  key: simulator/ringsimulator/ringsimulator/RfVoltage
+  device:
+    type: tango.pyaml.attribute
+    attribute: simulator/ringsimulator/ringsimulator/RfVoltage
+    unit: V
+- type: tango.pyaml.static_catalog_entry
+  key: simulator/ringsimulator/ringsimulator/Tune_v
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: simulator/ringsimulator/ringsimulator/Tune_v
+- type: tango.pyaml.static_catalog_entry
+  key: simulator/ringsimulator/ringsimulator/Tune_h
+  device:
+    type: tango.pyaml.attribute_read_only
+    attribute: simulator/ringsimulator/ringsimulator/Tune_h

--- a/examples/SOLEIL_examples/devices.yaml
+++ b/examples/SOLEIL_examples/devices.yaml
@@ -12112,17 +12112,11 @@
     y_pos: AN01-SD/DG-EPOS/BPM.01/y_pos
 - type: pyaml.rf.rf_plant
   name: RF
-  masterclock:
-    type: tango.pyaml.attribute
-    attribute: simulator/ringsimulator/ringsimulator/RfFrequency
-    unit: Hz
+  masterclock: simulator/ringsimulator/ringsimulator/RfFrequency
   transmitters:
   - type: pyaml.rf.rf_transmitter
     name: RFTRA
     cavities: [RF_002, RFHARMON_002]
     harmonic: 1
     distribution: 1
-    voltage:
-      type: tango.pyaml.attribute
-      attribute: simulator/ringsimulator/ringsimulator/RfVoltage
-      unit: V
+    voltage: simulator/ringsimulator/ringsimulator/RfVoltage

--- a/examples/SOLEIL_examples/p.yaml
+++ b/examples/SOLEIL_examples/p.yaml
@@ -14,9 +14,7 @@ controls:
 - type: tango.pyaml.controlsystem
   name: live
   tango_host: localhost:11000
-  catalog: bpm-catalog
-catalogs:
-- catalogs.yaml
+  catalog: catalogs.yaml
 arrays: arrays.yaml
 devices:
 - devices.yaml

--- a/examples/SOLEIL_examples/tuning_tools.yaml
+++ b/examples/SOLEIL_examples/tuning_tools.yaml
@@ -1,11 +1,7 @@
 - type: pyaml.diagnostics.tune_monitor
   name: BETATRON_TUNE
-  tune_h:
-    type: tango.pyaml.attribute_read_only
-    attribute: simulator/ringsimulator/ringsimulator/Tune_h
-  tune_v:
-    type: tango.pyaml.attribute_read_only
-    attribute: simulator/ringsimulator/ringsimulator/Tune_v
+  tune_h: simulator/ringsimulator/ringsimulator/Tune_h
+  tune_v: simulator/ringsimulator/ringsimulator/Tune_v
 - type: pyaml.tuning_tools.tune
   name: DEFAULT_TUNE_CORRECTION
   quad_array_name: QCORR

--- a/tests/config/bad_catalog_duplicate_key.yaml
+++ b/tests/config/bad_catalog_duplicate_key.yaml
@@ -6,7 +6,6 @@ data_folder: /data/store
 devices: []
 catalogs:
   - type: tango.pyaml.static_catalog
-    name: duplicate-refs
     entries:
       - type: tango.pyaml.static_catalog_entry
         key: duplicated/key

--- a/tests/config/catalogs/bpms_catalogs.yaml
+++ b/tests/config/catalogs/bpms_catalogs.yaml
@@ -1,5 +1,4 @@
 type: tango.pyaml.static_catalog
-name: bpm-catalog
 entries:
   - type: tango.pyaml.static_catalog_entry
     key: srdiag/bpm/c01-01/SA_HPosition

--- a/tests/config/catalogs/ebs_catalogs.yaml
+++ b/tests/config/catalogs/ebs_catalogs.yaml
@@ -1,5 +1,4 @@
 type: tango.pyaml.static_catalog
-name: ebs-catalog
 entries:
   - catalogs/ebs_bpm_catalogs.yaml
   - catalogs/ebs_rf_catalogs.yaml

--- a/tests/config/catalogs/shared_c04_bpm_catalogs.yaml
+++ b/tests/config/catalogs/shared_c04_bpm_catalogs.yaml
@@ -1,5 +1,4 @@
 type: tango.pyaml.static_catalog
-name: bpm-catalog
 entries:
   - type: tango.pyaml.static_catalog_entry
     key: srdiag/bpm/c04-01/SA_HPosition

--- a/tests/dummy_cs/tango-pyaml/tango/pyaml/catalog.py
+++ b/tests/dummy_cs/tango-pyaml/tango/pyaml/catalog.py
@@ -20,8 +20,6 @@ class CatalogConfigModel(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
-    name: str
-
 
 class Catalog(metaclass=ABCMeta):
     r"""
@@ -36,17 +34,6 @@ class Catalog(metaclass=ABCMeta):
 
     def __init__(self, cfg: CatalogConfigModel):
         self._cfg = cfg
-
-    def get_name(self) -> str:
-        r"""
-        Return the catalog name.
-
-        Returns
-        -------
-        str
-            Catalog identifier.
-        """
-        return self._cfg.name
 
     @abstractmethod
     def resolve(self, key: str) -> DeviceAccess:

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -25,7 +25,6 @@ def test_inline_catalog_is_supported(install_test_package):
                     "name": "live",
                     "catalog": {
                         "type": "tango.pyaml.static_catalog",
-                        "name": "inline-live",
                         "entries": [
                             {
                                 "type": "tango.pyaml.static_catalog_entry",
@@ -75,7 +74,7 @@ def test_inline_catalog_is_supported(install_test_package):
 def test_unresolved_catalog_key_raises_runtime_error(install_test_package):
     with pytest.raises(
         PyAMLConfigException,
-        match="Catalog 'device-catalog' cannot resolve key 'BPM_C03-01/y'",
+        match="Control system 'live' catalog cannot resolve key 'BPM_C03-01/y'",
     ):
         Accelerator.from_dict(
             {
@@ -91,7 +90,6 @@ def test_unresolved_catalog_key_raises_runtime_error(install_test_package):
                         "name": "live",
                         "catalog": {
                             "type": "tango.pyaml.static_catalog",
-                            "name": "device-catalog",
                             "entries": [
                                 {
                                     "type": "tango.pyaml.static_catalog_entry",
@@ -156,7 +154,6 @@ def test_indexed_catalog_entry_extracts_scalar_from_vector_attribute(install_tes
                     "name": "live",
                     "catalog": {
                         "type": "tango.pyaml.static_catalog",
-                        "name": "bpm-catalog",
                         "entries": [
                             {
                                 "type": "tango.pyaml.static_catalog_entry",


### PR DESCRIPTION
Adapting the catalogs and dummy CS to recent catalog evolutions in the backend so that test examples will work with the backends.

Closes #284 