### PR TITLE
Updated CS example

### DIFF
--- a/examples/ControlSystem/tango/main.py
+++ b/examples/ControlSystem/tango/main.py
@@ -1,4 +1,11 @@
 from pyaml.accelerator import Accelerator
 
 sr = Accelerator.load("config.yaml")
-print(sr.live.get_bpm("BPM_C01-01").positions.get())
+
+# print the BPM position
+bpm = sr.live.get_bpm("BPM_C01-01")  # bpm is a BPM
+print(bpm.positions.get())
+
+# Direct access to control system
+da = sr.live.get_device("srdiag/bpm/c01-01/SA_HPosition")  # da is a DeviceAccess
+print(f"h={da.get()} {da.unit()}")


### PR DESCRIPTION
This PR update example/ControlSystem/tango.

It shows how a `BPM` or `DeviceAccess` can be accessed.
It is similar here to a dynamic catalog in pyaml-cs-oa or tango-pyaml.

```python
from pyaml.accelerator import Accelerator

sr = Accelerator.load("config.yaml")

# print the BPM position
bpm = sr.live.get_bpm("BPM_C01-01") # bpm is a BPM
print(bpm.positions.get())

# Direct access to control system
da = sr.live.get_device("srdiag/bpm/c01-01/SA_HPosition") # da is a DeviceAccess
print(f"h={da.get()} {da.unit()}")
```

```
[ubuntu20acu.pons] > python main.py 
[-1.05921952e-05  3.91472705e-06]
h=-1.0592195175840235e-05 m
```