### PR TITLE
Rename get device access

### DIFF
--- a/examples/ControlSystem/tango/main.py
+++ b/examples/ControlSystem/tango/main.py
@@ -1,4 +1,11 @@
 from pyaml.accelerator import Accelerator
 
 sr = Accelerator.load("config.yaml")
-print(sr.live.get_bpm("BPM_C01-01").positions.get())
+
+# print the BPM position
+bpm = sr.live.get_bpm("BPM_C01-01")  # bpm is a BPM
+print(bpm.positions.get())
+
+# Direct access to control system
+da = sr.live.get_device("srdiag/bpm/c01-01/SA_HPosition")  # da is a DeviceAccess
+print(f"h={da.get()} {da.unit()}")

--- a/examples/ControlSystem/tango/main.py
+++ b/examples/ControlSystem/tango/main.py
@@ -7,5 +7,5 @@ bpm = sr.live.get_bpm("BPM_C01-01")  # bpm is a BPM
 print(bpm.positions.get())
 
 # Direct access to control system
-da = sr.live.get_device("srdiag/bpm/c01-01/SA_HPosition")  # da is a DeviceAccess
+da = sr.live.get_device_access("srdiag/bpm/c01-01/SA_HPosition")  # da is a DeviceAccess
 print(f"h={da.get()} {da.unit()}")

--- a/examples/ControlSystem/tango/tango_controlsystem.py
+++ b/examples/ControlSystem/tango/tango_controlsystem.py
@@ -112,7 +112,7 @@ class MyControlSystem(ControlSystemAdapter):
         super().__init__()
         self._cfg = cfg
 
-    def get_device(self, ref: str | BaseModel | None) -> DeviceAccess | None:
+    def get_device_access(self, ref: str | BaseModel | None) -> DeviceAccess | None:
         if ref is None:
             return None
         return MyDevice(self._cfg.prefix + ref)

--- a/pyaml/control/controlsystem.py
+++ b/pyaml/control/controlsystem.py
@@ -69,7 +69,7 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_device(self, ref: str | BaseModel | None) -> DeviceAccess:
+    def get_device_access(self, ref: str | BaseModel | None) -> DeviceAccess:
         """
         Return a device reference for this control system.
         YAML element configuration passes opaque strings. Public Python APIs may
@@ -78,7 +78,7 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
         """
         pass
 
-    def get_devices(self, refs: list[str | BaseModel | None]) -> list[DeviceAccess]:
+    def get_devices_access(self, refs: list[str | BaseModel | None]) -> list[DeviceAccess]:
         """
         Return a device reference for this control system.
         YAML element configuration passes opaque strings. Public Python APIs may
@@ -87,7 +87,7 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
         """
         if not isinstance(refs, list):
             raise PyAMLException(f"get_devices() expect a list as input arguments but got {str(type(refs))}")
-        return [self.get_device(ref) for ref in refs]
+        return [self.get_device_access(ref) for ref in refs]
 
     def _create_scalar_aggregator(self) -> ScalarAggregator | None:
         agg = self.get_aggregator()
@@ -126,7 +126,7 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
         if agg is None or aggh is None or aggv is None:
             return [None, None, None]
         for b in bpms:
-            devs = self.get_devices(b.model.get_pos_devices())
+            devs = self.get_devices_access(b.model.get_pos_devices())
             agg.add_devices(devs)
             aggh.add_devices(devs[0])
             aggv.add_devices(devs[1])
@@ -180,9 +180,9 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
                     self.add_magnet(m)
 
             elif isinstance(e, BPM):
-                pos_devs = self.get_devices(e.model.get_pos_devices())
-                tilt_devs = self.get_devices([e.model.get_tilt_device()])
-                offset_devs = self.get_devices(e.model.get_offset_devices())
+                pos_devs = self.get_devices_access(e.model.get_pos_devices())
+                tilt_devs = self.get_devices_access([e.model.get_tilt_device()])
+                offset_devs = self.get_devices_access(e.model.get_offset_devices())
                 positions = RBpmArray(pos_devs[0], pos_devs[1])
                 tilt = RWBpmTiltScalar(tilt_devs[0])
                 offsets = RWBpmOffsetArray(offset_devs[0], offset_devs[1])
@@ -193,15 +193,15 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
                 attachedTrans: list[RFTransmitter] = []
                 if e._cfg.transmitters:
                     for t in e._cfg.transmitters:
-                        vDev = self.get_device(t._cfg.voltage)
-                        pDev = self.get_device(t._cfg.phase)
+                        vDev = self.get_device_access(t._cfg.voltage)
+                        pDev = self.get_device_access(t._cfg.phase)
                         voltage = RWRFVoltageScalar(t, vDev)
                         phase = RWRFPhaseScalar(t, pDev)
                         nt = t.attach(self, voltage, phase)
                         self.add_rf_transnmitter(nt)
                         attachedTrans.append(nt)
 
-                fDev = self.get_device(e._cfg.masterclock)
+                fDev = self.get_device_access(e._cfg.masterclock)
                 frequency = RWRFFrequencyScalar(e, fDev)
                 voltage = RWTotalVoltage(attachedTrans) if e._cfg.transmitters else None
                 ne = e.attach(self, frequency, voltage)
@@ -209,7 +209,7 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
 
             elif isinstance(e, BetatronTuneMonitor):
                 # Built in tune monitor
-                tuneDevs = self.get_devices([e._cfg.tune_h, e._cfg.tune_v])
+                tuneDevs = self.get_devices_access([e._cfg.tune_h, e._cfg.tune_v])
                 betatron_tune = RBetatronTuneArray(e, tuneDevs)
                 e = e.attach(self, betatron_tune)
                 self.add_betatron_tune_monitor(e)
@@ -248,5 +248,5 @@ class ControlSystemAdapter(ControlSystem):
     def get_aggregator(self) -> DeviceAccessList | None:
         return None
 
-    def get_device(self, ref: str | BaseModel | None) -> DeviceAccess | None:
+    def get_device_access(self, ref: str | BaseModel | None) -> DeviceAccess | None:
         pass

--- a/tests/bpm/test_bpm_controlsystem.py
+++ b/tests/bpm/test_bpm_controlsystem.py
@@ -58,7 +58,7 @@ def test_controlsystem_bpm_position(install_test_package):
 def test_controlsystem_get_devices_returns_attached_devices(install_test_package):
     sr: Accelerator = Accelerator.load("tests/config/bpms.yaml")
 
-    devs = sr.live.get_devices(["srdiag/bpm/c01-01/SA_HPosition", "srdiag/bpm/c01-01/SA_VPosition"])
+    devs = sr.live.get_devices_access(["srdiag/bpm/c01-01/SA_HPosition", "srdiag/bpm/c01-01/SA_VPosition"])
 
     assert devs[0].name() == "//ebs-simu-3:10000/srdiag/bpm/c01-01/SA_HPosition"
     assert devs[1].name() == "//ebs-simu-3:10000/srdiag/bpm/c01-01/SA_VPosition"
@@ -74,7 +74,7 @@ def test_controlsystem_get_device_accepts_backend_config_model(install_test_pack
 
     sr: Accelerator = Accelerator.load("tests/config/bpms.yaml")
 
-    dev = sr.live.get_device(AttributeConfigModel(attribute="srdiag/bpm/c01-05/SA_HPosition", unit="mm"))
+    dev = sr.live.get_device_access(AttributeConfigModel(attribute="srdiag/bpm/c01-05/SA_HPosition", unit="mm"))
 
     assert dev.name() == "//ebs-simu-3:10000/srdiag/bpm/c01-05/SA_HPosition"
     assert dev.unit() == "mm"

--- a/tests/control/test_aggregator.py
+++ b/tests/control/test_aggregator.py
@@ -12,10 +12,10 @@ from pyaml.accelerator import Accelerator
 def test_aggregator(install_test_package):
     sr = Accelerator.load("tests/config/sr.yaml")
     agg = sr.live.get_aggregator()
-    agg.add_devices(sr.live.get_device("srdiag/bpm/c04-01/SA_HPosition"))
-    agg.add_devices(sr.live.get_device("srdiag/bpm/c04-01/SA_VPosition"))
-    agg.add_devices(sr.live.get_device("srdiag/bpm/c04-02/SA_HPosition"))
-    agg.add_devices(sr.live.get_device("srdiag/bpm/c04-02/SA_VPosition"))
+    agg.add_devices(sr.live.get_device_access("srdiag/bpm/c04-01/SA_HPosition"))
+    agg.add_devices(sr.live.get_device_access("srdiag/bpm/c04-01/SA_VPosition"))
+    agg.add_devices(sr.live.get_device_access("srdiag/bpm/c04-02/SA_HPosition"))
+    agg.add_devices(sr.live.get_device_access("srdiag/bpm/c04-02/SA_VPosition"))
 
     # Iterator and index
     assert agg.len() == 4
@@ -28,7 +28,7 @@ def test_aggregator(install_test_package):
 
     # Immutable behavior
     with pytest.raises(TypeError, match="does not support item assignment"):
-        agg[1] = sr.live.get_device("srdiag/bpm/c04-01/SA_HPosition")
+        agg[1] = sr.live.get_device_access("srdiag/bpm/c04-01/SA_HPosition")
 
     # Values
     assert np.shape(agg.get()) == (4,)

--- a/tests/dummy_cs/tango-pyaml/tango/pyaml/controlsystem.py
+++ b/tests/dummy_cs/tango-pyaml/tango/pyaml/controlsystem.py
@@ -37,7 +37,7 @@ class TangoControlSystem(ControlSystem):
     def attach(self, devs: list[DeviceAccess | None]) -> list[DeviceAccess | None]:
         return self._attach(devs, False)
 
-    def get_device(self, ref: str | BaseModel | None) -> DeviceAccess | None:
+    def get_device_access(self, ref: str | BaseModel | None) -> DeviceAccess | None:
         if ref is None:
             return None
 


### PR DESCRIPTION
This PR renames `ControlSytem.get_device()` to `ControlSytem.get_device_access()` 