### PR TITLE
Fixes to factory to handle ignore_external.

### DIFF
--- a/pyaml/accelerator.py
+++ b/pyaml/accelerator.py
@@ -70,8 +70,8 @@ class Accelerator(object):
 
     def __init__(self, cfg: ConfigModel):
         self._cfg = cfg
-        __design = None
-        __live = None
+        self.__design = None
+        self.__live = None
         self._controls: dict[str, ElementHolder] = {}
         self._simulators: dict[str, ElementHolder] = {}
 

--- a/pyaml/configuration/factory.py
+++ b/pyaml/configuration/factory.py
@@ -380,6 +380,10 @@ class PyAMLFactory:
         """
 
         build_info = resolve_build_info(data, ignore_external)
+
+        if build_info is None:
+            return None
+
         config_cls = build_info.config_cls
 
         result = dict(data)
@@ -487,6 +491,9 @@ class PyAMLFactory:
 
         # Get the build information
         build_info = resolve_build_info(data, ignore_external)
+        if build_info is None:
+            return None
+
         module = build_info.module
         config_cls = build_info.config_cls
         class_str = build_info.class_str
@@ -548,6 +555,8 @@ class PyAMLFactory:
 
         elif isinstance(data, dict):
             data = self._build_dict(data, ignore_external)
+            if data is None:
+                return None
             return self.build_object(data, ignore_external)
 
     def clear(self):

--- a/pyaml/magnet/linear_model.py
+++ b/pyaml/magnet/linear_model.py
@@ -60,9 +60,15 @@ class LinearMagnetModel(MagnetModel):
             self.__g = cfg.calibration_factor * cfg.crosstalk
             self.__o = cfg.calibration_offset
         self.__strength_unit = cfg.unit
-        self.__hardware_unit = cfg.powerconverter.unit()
+
+        if cfg.powerconverter is not None:
+            self.__hardware_unit = cfg.powerconverter.unit()
+            self.__ps = cfg.powerconverter
+        else:
+            self.__hardware_unit = None
+            self.__ps = None
+
         self.__brho = np.nan
-        self.__ps = cfg.powerconverter
 
     def compute_hardware_values(self, strengths: np.array) -> np.array:
         if self.__rcurve is not None:


### PR DESCRIPTION
This is to fix issue #292.

I have added so the factory returns None instead of building an object if ignore_external = True and the module isn't found.

I had to also add a fix in the linear magnet module to handle the case when the powerconverter becomes None.