### PR TITLE
Move functionality to handle root folder into one class.

### DIFF
--- a/pyaml/configuration/__init__.py
+++ b/pyaml/configuration/__init__.py
@@ -3,13 +3,12 @@ PyAML configuration module
 """
 
 from .factory import Factory
-from .fileloader import get_root_folder, set_root_folder
+from .fileloader import ROOT
 from .manager import ConfigurationManager, UnsupportedConfigurationRootError
 
 __all__ = [
     "ConfigurationManager",
     "UnsupportedConfigurationRootError",
     "Factory",
-    "get_root_folder",
-    "set_root_folder",
+    "ROOT",
 ]

--- a/pyaml/configuration/fileloader.py
+++ b/pyaml/configuration/fileloader.py
@@ -1,11 +1,13 @@
-# PyAML config file loader
+""" "PyAML configuration file loader."""
+
 import collections.abc
 import io
 import json
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import yaml
 from yaml import CLoader
@@ -16,42 +18,49 @@ from pyaml.configuration.factory import Factory
 
 from .. import PyAMLException
 
-if TYPE_CHECKING:
-    from pyaml.accelerator import Accelerator
-
-
 logger = logging.getLogger(__name__)
 
 accepted_suffixes = [".yaml", ".yml", ".json"]
 FILE_PREFIX = "file:"
 
-ROOT = {"path": Path.cwd().resolve()}
+
+class RootFolder:
+    """
+    Manage the root directory used to resolve relative configuration paths.
+    """
+
+    def __init__(self, path: str | Path | None = None):
+        # Resolve the path is given otherwise set to the current working directory
+        if path is None:
+            self._path = Path.cwd().resolve()
+        else:
+            self._path = Path(path).resolve()
+
+    def set(self, path: str | Path) -> None:
+        """
+        Set the root path for configuration files.
+        """
+        self._path = Path(path).resolve()
+
+    def get(self) -> Path:
+        """
+        Get the root path for configuration files.
+        """
+        return self._path
+
+    def expand_path(self, path: str | Path) -> Path:
+        """
+        Return an absolute configuration path.
+
+        Relative paths are interpreted relative to the configured root
+        folder. Absolute paths are returned unchanged.
+        """
+
+        path = Path(path)
+        return path if path.is_absolute() else self._path / path
 
 
-def set_root_folder(path: Union[str, Path]):
-    """
-    Set the root path for configuration files.
-    """
-    ROOT["path"] = Path(path)
-
-
-def get_root_folder() -> Path:
-    """
-    Get the root path for configuration files.
-    """
-    return ROOT["path"]
-
-
-def get_path(p: Path) -> Path:
-    """
-    Return unchanged input path if it is an absolute path,
-    path relative to root folder otherwise.
-    """
-    if os.path.isabs(p):
-        return p
-    else:
-        root = get_root_folder()
-        return root / p
+ROOT = RootFolder()
 
 
 class PyAMLConfigCyclingException(PyAMLException):
@@ -63,8 +72,46 @@ class PyAMLConfigCyclingException(PyAMLException):
     pass
 
 
+@dataclass(frozen=True)
+class Location:
+    """
+    Source location within a configuration file.
+    """
+
+    file: str
+    line: int
+    column: int
+
+    def __str__(self) -> str:
+        return f"{self.file} at line {self.line}, column {self.column}."
+
+
+@dataclass(frozen=True)
+class LocationMetadata:
+    """
+    Location metadata extracted from configuration data.
+    """
+
+    location: Location | None
+    field_locations: dict[str, Location] | None = None
+
+
+@dataclass(frozen=True)
+class LoadedConfig:
+    """
+    Loaded configuration plus separate metadata.
+
+    metadata maps id(obj) -> LocationMetadata for every dict/list node
+    produced by the loader.
+    """
+
+    data: dict | list
+    metadata: dict[int, LocationMetadata]
+
+
 def load(filename: str, paths_stack: list = None, use_fast_loader: bool = False) -> Union[dict, list]:
     """Load recursively a configuration setup"""
+
     if filename.endswith(".yaml") or filename.endswith(".yml"):
         l = YAMLLoader(filename, paths_stack, use_fast_loader)
     elif filename.endswith(".json"):
@@ -82,7 +129,7 @@ def hasToLoad(value):
 # Loader base class (nested files expansion)
 class Loader:
     def __init__(self, filename: str, parent_path_stack: list[Path]):
-        self.path: Path = get_path(filename)
+        self.path: Path = ROOT.expand_path(filename)
         self.files_stack: list[Path] = []
         if parent_path_stack:
             if any(self.path.samefile(parent_path) for parent_path in parent_path_stack):
@@ -98,7 +145,7 @@ class Loader:
                     if value.startswith(FILE_PREFIX):
                         # remove prefix
                         stripped_value = value[len(FILE_PREFIX) :]
-                        d[key] = str(get_root_folder() / Path(stripped_value))
+                        d[key] = str(ROOT.get() / Path(stripped_value))
                     else:
                         d[key] = load(value, self.files_stack, self.use_fast_loader)
                 else:

--- a/pyaml/configuration/fileloader.py
+++ b/pyaml/configuration/fileloader.py
@@ -72,46 +72,8 @@ class PyAMLConfigCyclingException(PyAMLException):
     pass
 
 
-@dataclass(frozen=True)
-class Location:
-    """
-    Source location within a configuration file.
-    """
-
-    file: str
-    line: int
-    column: int
-
-    def __str__(self) -> str:
-        return f"{self.file} at line {self.line}, column {self.column}."
-
-
-@dataclass(frozen=True)
-class LocationMetadata:
-    """
-    Location metadata extracted from configuration data.
-    """
-
-    location: Location | None
-    field_locations: dict[str, Location] | None = None
-
-
-@dataclass(frozen=True)
-class LoadedConfig:
-    """
-    Loaded configuration plus separate metadata.
-
-    metadata maps id(obj) -> LocationMetadata for every dict/list node
-    produced by the loader.
-    """
-
-    data: dict | list
-    metadata: dict[int, LocationMetadata]
-
-
 def load(filename: str, paths_stack: list = None, use_fast_loader: bool = False) -> Union[dict, list]:
     """Load recursively a configuration setup"""
-
     if filename.endswith(".yaml") or filename.endswith(".yml"):
         l = YAMLLoader(filename, paths_stack, use_fast_loader)
     elif filename.endswith(".json"):

--- a/pyaml/configuration/fileloader.py
+++ b/pyaml/configuration/fileloader.py
@@ -4,17 +4,13 @@ import collections.abc
 import io
 import json
 import logging
-import os
-from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union
+from typing import Union
 
 import yaml
 from yaml import CLoader
 from yaml.constructor import ConstructorError
 from yaml.loader import SafeLoader
-
-from pyaml.configuration.factory import Factory
 
 from .. import PyAMLException
 

--- a/pyaml/configuration/manager.py
+++ b/pyaml/configuration/manager.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from ..common.exception import PyAMLConfigException
-from .fileloader import get_root_folder, load, set_root_folder
+from .fileloader import ROOT, load
 from .restfetcher import REMOTE_BASE_URL_KEY, SourceRoot, fetch_remote_config, is_remote_url, resolve_reference
 
 _INTERNAL_METADATA_KEYS = {"__location__", "__fieldlocations__", REMOTE_BASE_URL_KEY}
@@ -109,7 +109,7 @@ class ConfigurationManager:
         self._items_by_category: dict[str, dict[str, dict[str, Any]]] = {category: {} for category in self.NAMED_CATEGORIES}
         self._sources_by_category: dict[str, dict[str, str]] = {category: {} for category in self.NAMED_CATEGORIES}
         self._field_sources: dict[str, str] = {}
-        self._build_root: SourceRoot = get_root_folder()
+        self._build_root: SourceRoot = ROOT.get()
         self._build_root_locked = False
 
     def add(self, payload, **kwargs) -> None:
@@ -258,7 +258,7 @@ class ConfigurationManager:
             for name in self.NAMED_CATEGORIES:
                 self._items_by_category[name].clear()
                 self._sources_by_category[name].clear()
-            self._build_root = get_root_folder()
+            self._build_root = ROOT.get()
             self._build_root_locked = False
             return
 
@@ -491,7 +491,7 @@ class ConfigurationManager:
         from ..accelerator import Accelerator
 
         if isinstance(self._build_root, Path):
-            set_root_folder(self._build_root)
+            ROOT.set(self._build_root)
         snapshot = ConfigurationManager.strip_runtime_internal_metadata(self._snapshot(include_internal_metadata=True))
         return Accelerator.from_dict(snapshot, ignore_external=ignore_external)
 
@@ -624,13 +624,13 @@ class ConfigurationManager:
             raise PyAMLConfigException(f"{payload_path} file not found")
 
         resolved_path = path.resolve()
-        previous_root = get_root_folder()
+        previous_root = ROOT.get()
         source_root = resolved_path.parent
         try:
-            set_root_folder(source_root)
+            ROOT.set(source_root)
             fragment = load(resolved_path.name, None, use_fast_loader)
         finally:
-            set_root_folder(previous_root)
+            ROOT.set(previous_root)
 
         if not self._build_root_locked:
             self._build_root = source_root

--- a/pyaml/lattice/simulator.py
+++ b/pyaml/lattice/simulator.py
@@ -8,7 +8,7 @@ from ..common.abstract_aggregator import ScalarAggregator
 from ..common.element import Element
 from ..common.element_holder import ElementHolder
 from ..common.exception import PyAMLException
-from ..configuration import get_root_folder
+from ..configuration import ROOT
 from ..diagnostics.tune_monitor import BetatronTuneMonitor
 from ..lattice.abstract_impl import (
     BPMHScalarAggregator,
@@ -84,7 +84,7 @@ class Simulator(ElementHolder):
     def __init__(self, cfg: ConfigModel):
         super().__init__()
         self._cfg = cfg
-        path: Path = get_root_folder() / cfg.lattice
+        path: Path = ROOT.get() / cfg.lattice
 
         if self._cfg.mat_key is None:
             self.ring = at.load_lattice(path)

--- a/pyaml/magnet/csvcurve.py
+++ b/pyaml/magnet/csvcurve.py
@@ -4,7 +4,7 @@ import numpy as np
 from pydantic import BaseModel, ConfigDict
 
 from ..common.exception import PyAMLException
-from ..configuration.fileloader import get_path
+from ..configuration.fileloader import ROOT
 from .curve import Curve
 
 # Define the main class name for this module
@@ -35,7 +35,7 @@ class CSVCurve(Curve):
         self._cfg = cfg
 
         # Load CSV curve
-        path = get_path(cfg.file)
+        path = ROOT.expand_path(cfg.file)
         try:
             self._curve = np.genfromtxt(path, delimiter=",", dtype=float, loose=False)
         except ValueError as e:

--- a/pyaml/magnet/csvmatrix.py
+++ b/pyaml/magnet/csvmatrix.py
@@ -4,7 +4,7 @@ import numpy as np
 from pydantic import BaseModel, ConfigDict
 
 from ..common.exception import PyAMLException
-from ..configuration.fileloader import get_path
+from ..configuration.fileloader import ROOT
 from .matrix import Matrix
 
 # Define the main class name for this module
@@ -34,7 +34,7 @@ class CSVMatrix(Matrix):
     def __init__(self, cfg: ConfigModel):
         self._cfg = cfg
         # Load CSV matrix
-        path = get_path(cfg.file)
+        path = ROOT.expand_path(cfg.file)
         try:
             self._mat = np.genfromtxt(path, delimiter=",", dtype=float, loose=False)
         except ValueError as e:

--- a/pyaml/magnet/inline_curve.py
+++ b/pyaml/magnet/inline_curve.py
@@ -4,7 +4,6 @@ import numpy as np
 from pydantic import BaseModel, ConfigDict
 
 from ..common.exception import PyAMLException
-from ..configuration import get_root_folder
 from .curve import Curve
 
 # Define the main class name for this module

--- a/tests/configuration/test_curve.py
+++ b/tests/configuration/test_curve.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from pyaml.configuration import set_root_folder
+from pyaml.configuration import ROOT
 from pyaml.magnet.csvcurve import ConfigModel, CSVCurve
 from pyaml.magnet.curve import Curve
 
@@ -17,6 +17,6 @@ def curve_test(file: str, current: float, strength: float):
 
 
 def test_curve(config_root_dir):
-    set_root_folder(config_root_dir)
+    ROOT.set(config_root_dir)
     curve_test("sr/magnet_models/QF1_strength.csv", 85, 16.618788)
     curve_test("sr/magnet_models/QD2_strength.csv", 87, -12.319894)

--- a/tests/configuration/test_factory.py
+++ b/tests/configuration/test_factory.py
@@ -2,7 +2,7 @@ import pytest
 
 from pyaml import PyAMLConfigException, PyAMLException
 from pyaml.accelerator import Accelerator
-from pyaml.configuration import get_root_folder, set_root_folder
+from pyaml.configuration import ROOT
 from pyaml.configuration.factory import Factory
 from pyaml.configuration.fileloader import load
 from tests.conftest import MockElement
@@ -23,14 +23,14 @@ def test_factory_build_default():
     ],
 )
 def test_error_location(test_file):
-    previous_root = get_root_folder()
+    previous_root = ROOT.get()
     try:
         with pytest.raises(PyAMLConfigException) as exc:
-            set_root_folder("tests/config")
+            ROOT.set("tests/config")
             cfg = load("bad_conf.yml")
             Factory.build(cfg, False)
     finally:
-        set_root_folder(previous_root)
+        ROOT.set(previous_root)
     print(str(exc.value))
     test_file_names = test_file.split("/")
     test_file_name = test_file_names[len(test_file_names) - 1]

--- a/tests/magnet/test_load_quad.py
+++ b/tests/magnet/test_load_quad.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from scipy.constants import speed_of_light
 
-from pyaml.configuration import Factory, get_root_folder, set_root_folder
+from pyaml.configuration import ROOT, Factory
 from pyaml.configuration.fileloader import load
 from pyaml.control.abstract_impl import (
     RWHardwareArray,
@@ -30,7 +30,7 @@ from pyaml.magnet.quadrupole import Quadrupole
     indirect=True,
 )
 def test_quad_external_model(install_test_package, config_root_dir):
-    set_root_folder(config_root_dir)
+    ROOT.set(config_root_dir)
     cfg_hcorr_yaml = load("sr/custom_magnets/hidcorr.yaml")
     cs = Factory.build_object(
         {
@@ -71,7 +71,7 @@ def test_quad_external_model(install_test_package, config_root_dir):
     indirect=["install_test_package"],
 )
 def test_quad_linear(magnet_file, install_test_package, config_root_dir):
-    set_root_folder(config_root_dir)
+    ROOT.set(config_root_dir)
     cfg_quad = load(magnet_file)
     print(f"Current file: {config_root_dir}/{magnet_file}")
     cs = Factory.build_object(
@@ -121,7 +121,7 @@ def test_quad_linear(magnet_file, install_test_package, config_root_dir):
     ],
 )
 def test_combined_function_magnets(magnet_file, config_root_dir):
-    set_root_folder(config_root_dir)
+    ROOT.set(config_root_dir)
     cfg_sh = load(magnet_file)
     cs = Factory.build_object(
         {


### PR DESCRIPTION
I have made some small changes to gather all the functionality to handle the root folder into one class.

The purpose is just to make it easier to for the users to understand which methods are available for this and distinguish them from other functionality in the fileloader module.

**Differences:**

- Instead of having to import `get_root_folder`, `set_root_folder` and `get_path` individually you now just can import `ROOT` and it will return a module level object for the current root folder.
- You then can do `ROOT.get()`, `ROOT.set()` and `ROOT.expand_path()` for the same functionality as before.