### PR TITLE
Update bba callback

### DIFF
--- a/pyaml/tuning_tools/bba.py
+++ b/pyaml/tuning_tools/bba.py
@@ -148,6 +148,7 @@ class BBA(MeasurementTool):
             bipolar=False,
             skip_save=True,
             plane=plane,
+            live_ios=True,
         )
 
         pySC.disable_pySC_rich()
@@ -162,13 +163,30 @@ class BBA(MeasurementTool):
             self.latest_measurement["HData"] = None
             self.latest_measurement["VData"] = None
             for code, measurement_object in generator:
-                if code == BBACode.HORIZONTAL:
-                    self.send_callback(Action.MEASURE, {"step": hstep, "plane": "H", "bba_data": measurement_object.H_data})
+                if code == BBACode.HORIZONTAL_IOS_READY:
+                    self.send_callback(
+                        Action.MEASURE,
+                        {
+                            "step": hstep,
+                            "plane": "H",
+                            "bpm_pos": measurement_object.last_bpm_pos,
+                            "ios": measurement_object.last_ios,
+                            "bba_data": measurement_object.H_data,
+                        },
+                    )
                     hstep += 1
-                if code == BBACode.VERTICAL:
-                    self.send_callback(Action.MEASURE, {"step": vstep, "plane": "V", "bba_data": measurement_object.V_data})
+                if code == BBACode.VERTICAL_IOS_READY:
+                    self.send_callback(
+                        Action.MEASURE,
+                        {
+                            "step": vstep,
+                            "plane": "V",
+                            "bpm_pos": measurement_object.last_bpm_pos,
+                            "ios": measurement_object.last_ios,
+                            "bba_data": measurement_object.V_data,
+                        },
+                    )
                     vstep += 1
-
                 if code == BBACode.HORIZONTAL_DONE:
                     result = BBAAnalysis.analyze(measurement_object.H_data)
                     self.latest_measurement["HData"] = result

--- a/pyaml/tuning_tools/bba.py
+++ b/pyaml/tuning_tools/bba.py
@@ -138,6 +138,7 @@ class BBA(MeasurementTool):
         }
 
         # logging.getLogger("pySC.apps.measurements").setLevel(logging.DEBUG)
+        # logging.getLogger("pySC.apps.bba").setLevel(logging.DEBUG)
 
         generator = measure_bba(
             interface=interface,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "accelerator-toolbox>=0.6.1",
     "PyYAML>=6.0.2",
     "pydantic>=2.11.7",
-    "accelerator-commissioning==1.5.2", #pySC
+    "accelerator-commissioning==1.5.3", #pySC
     "h5py",
     "matplotlib"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "accelerator-toolbox>=0.6.1",
     "PyYAML>=6.0.2",
     "pydantic>=2.11.7",
-    "accelerator-commissioning==1.3.0", #pySC
+    "accelerator-commissioning==1.5.2", #pySC
     "h5py",
     "matplotlib"
 ]


### PR DESCRIPTION
This PR improve BBA callback using new pySC (1.5.3).

Example:

```python
from pyaml.accelerator import Accelerator
from pyaml.common.constants import Action
import numpy as np

ios_x = {"H":[],"V":[]}
ios_y = {"H":[],"V":[]}

def bba_callback(action: int, cdata):

    # Action.MEASURE is triggered at each new IOS measurement
    if action == Action.MEASURE:
        plane = cdata["plane"]
        step = cdata["step"]
        ios_x[plane].append(cdata["bpm_pos"])
        ios_y[plane].append(cdata["ios"])
        if len(ios_x[plane])>=2:
            # Get slopes
            fit = np.polynomial.polynomial.polyfit(ios_x[plane], ios_y[plane], 1)
            # Extract small slopes
            std = np.std(fit[1])
            cfit = fit[:,np.where(np.fabs(fit[1])>=std)[0]]
            # Get average intersection point (-> offset)
            x = np.mean(-cfit[0] / cfit[1])
            print(f"step={step} plane={cdata["plane"]} pos={cdata["bpm_pos"]*1e6:7.3f} um offset={x*1e6:.3f} um")
    return True

sr = Accelerator.load("tests/config/EBSOrbit.yaml")
SR = sr.design
bba = SR.get_bba("BBA-BPM_C04-04")

# Add a misalignement
SR.get_bpm("BPM_C04-04").offset.set([20e-6,-15e-6])

bba.measure(callback=bba_callback)

print(f"HOffset: {bba.h_offset()}")
print(f"VOffset: {bba.v_offset()}")
```

outputs:

```
step=1 plane=H pos= 52.151 um offset=19.750 um
step=2 plane=H pos= 36.095 um offset=19.864 um
step=3 plane=H pos= 19.995 um offset=19.959 um
step=4 plane=H pos=  3.854 um offset=20.036 um
step=5 plane=H pos=-12.324 um offset=20.097 um
step=6 plane=H pos=-28.534 um offset=20.141 um
step=1 plane=V pos=  6.527 um offset=-15.002 um
step=2 plane=V pos= -4.236 um offset=-15.001 um
step=3 plane=V pos=-15.000 um offset=-15.000 um
step=4 plane=V pos=-25.764 um offset=-15.000 um
step=5 plane=V pos=-36.527 um offset=-15.000 um
step=6 plane=V pos=-47.290 um offset=-15.000 um
HOffset: 2.0149059939587564e-05
VOffset: -1.5000000000143988e-05
```
