### PR TITLE
Minor fix for error propagation and silent quad

### DIFF
--- a/pyaml/tuning_tools/bba2.py
+++ b/pyaml/tuning_tools/bba2.py
@@ -99,12 +99,12 @@ class BBA2(MeasurementTool):
         xx = np.polynomial.polynomial.polyfit(x[-n:], k[-n:], 1)
         err = 0
         if n > 2:
-            # Compute error on the ratio -xx[0] / xx[1]
+            # Compute error of the ratio r = -xx[0] / xx[1]
             X = np.polynomial.polynomial.polyvander(x[-n:], 1)
             R = k[-n:] - X @ xx
             S2 = np.sum(R**2) / float(n - 2)
             COV = S2 * np.linalg.inv(X.T @ X)
-            J = [1 / xx[1], -xx[0] / xx[1] ** 2]
+            J = [-1 / xx[1], xx[0] / xx[1] ** 2]  # Jacobian [dr/d(xx[0]) , dr/d(xx[1])]
             err = np.sqrt(J @ COV @ J)
 
         # return x @y=0

--- a/pyaml/tuning_tools/bba2.py
+++ b/pyaml/tuning_tools/bba2.py
@@ -346,7 +346,7 @@ class BBA2(MeasurementTool):
         # Initial values
         self._initial_k0 = [self._h_steer.strength.get(), self._v_steer.strength.get()]
         self._initial_k1 = self._quad.strength.get()
-        self._quad_polarity = np.sign(self._initial_k1)
+        self._quad_polarity = np.sign(self._initial_k1) if self._initial_k1 != 0 else 1
 
         self._ref_ios, fx, fy = self._init_responses(
             self._cfg.tune_correction_name,


### PR DESCRIPTION
This PR fixes error propagation calculation and silent quad.
- The sign bug in uncertainty propagation calculation does not change the result (-a/b is the same as a/b) but clarifies the code.
- Fix for quad with zero strength (i.e. quadrupole corrector) that produces silent scan