### PR TITLE
Update workflow for unit tests to test against several python versions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -18,7 +19,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: >-
+          ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+              && fromJSON(vars.PYTHON_ALL_SUPPORTED_TEST_VERSIONS)
+              || fromJSON(vars.PYTHON_DEFAULT_TEST_VERSIONS) }}
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,7 +1,7 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# This workflow will install Python dependencies, run tests and lint with a several version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: run tests
+name: Run unit tests
 
 on:
   push:
@@ -15,15 +15,19 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v7
       with:
-        submodules: recursive
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v3
-      with:
-        python-version: ">=3.12"
+        python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -31,11 +35,16 @@ jobs:
         pip install ./tests/dummy_cs/tango-pyaml
         pip install ./tests/external
         pip install flake8
+
+    - name: Display Python version
+      run: python -c "import sys; print(sys.version)"
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
     - name: Test with pytest
       run: python -m pytest tests


### PR DESCRIPTION
I have updated the github workflow to run the unit tests for python 3.11-3.14 to automatically be able to catch any compatibility issues.

I also upgraded the github actions to use the latest versions.