### PR TITLE
Refactor element attachment with holder-specific dispatch

### DIFF
--- a/pyaml/accelerator.py
+++ b/pyaml/accelerator.py
@@ -100,7 +100,7 @@ class Accelerator:
                 else:
                     # Add as dynamic attribute
                     setattr(self, c.name(), c)
-                c.fill_device(self._devices)
+                c._fill_device(self._devices)
                 c._peer = self
                 self._controls[c.name()] = c
 
@@ -111,7 +111,7 @@ class Accelerator:
                 else:
                     # Add as dynamic attribute
                     setattr(self, s.name(), s)
-                s.fill_device(self._devices)
+                s._fill_device(self._devices)
                 s._peer = self
                 self._simulators[s.name()] = s
 
@@ -201,11 +201,11 @@ class Accelerator:
         self._devices.append(dev)
         if self._controls is not None:
             for c in self._controls:
-                c.fill_device([dev])
+                c._fill_device([dev])
 
         if self._simulators is not None:
             for s in self._simulators:
-                s.fill_device([dev])
+                s._fill_device([dev])
 
     def post_init(self):
         """

--- a/pyaml/accelerator.py
+++ b/pyaml/accelerator.py
@@ -100,7 +100,7 @@ class Accelerator:
                 else:
                     # Add as dynamic attribute
                     setattr(self, c.name(), c)
-                c._fill_device(self._devices)
+                c.fill_device(self._devices)
                 c._peer = self
                 self._controls[c.name()] = c
 
@@ -111,7 +111,7 @@ class Accelerator:
                 else:
                     # Add as dynamic attribute
                     setattr(self, s.name(), s)
-                s._fill_device(self._devices)
+                s.fill_device(self._devices)
                 s._peer = self
                 self._simulators[s.name()] = s
 
@@ -201,11 +201,11 @@ class Accelerator:
         self._devices.append(dev)
         if self._controls is not None:
             for c in self._controls:
-                c._fill_device([dev])
+                c.fill_device([dev])
 
         if self._simulators is not None:
             for s in self._simulators:
-                s._fill_device([dev])
+                s.fill_device([dev])
 
     def post_init(self):
         """

--- a/pyaml/bpm/bpm.py
+++ b/pyaml/bpm/bpm.py
@@ -151,6 +151,9 @@ class BPM(Element, DynamicValidation):
         obj._peer = peer
         return obj
 
+    def fill_device(self, holder) -> None:
+        holder.fill_bpm(self)
+
     def get_pos_devices(self) -> list[str | None]:
         """
         Get device handles used for position reading

--- a/pyaml/bpm/bpm.py
+++ b/pyaml/bpm/bpm.py
@@ -151,8 +151,8 @@ class BPM(Element, DynamicValidation):
         obj._peer = peer
         return obj
 
-    def fill_device(self, holder) -> None:
-        holder.fill_bpm(self)
+    def _fill_device(self, holder) -> None:
+        holder._fill_bpm(self)
 
     def get_pos_devices(self) -> list[str | None]:
         """

--- a/pyaml/common/holders/element_holder.py
+++ b/pyaml/common/holders/element_holder.py
@@ -37,14 +37,17 @@ from .sub_holders import (
 
 if TYPE_CHECKING:
     from ...accelerator import Accelerator
+    from ...configuration.unbound_element import UnboundElement
     from ...tuning_tools.bba import BBA
     from ...tuning_tools.chromaticity import Chromaticity
     from ...tuning_tools.chromaticity_response_matrix import ChromaticityResponseMatrix
     from ...tuning_tools.dispersion import Dispersion
+    from ...tuning_tools.measurement_tool import MeasurementTool
     from ...tuning_tools.orbit import Orbit
     from ...tuning_tools.orbit_response_matrix import OrbitResponseMatrix
     from ...tuning_tools.tune import Tune
     from ...tuning_tools.tune_response_matrix import TuneResponseMatrix
+    from ...tuning_tools.tuning_tool import TuningTool
 
 
 class ElementHolder(metaclass=ABCMeta):
@@ -145,7 +148,40 @@ class ElementHolder(metaclass=ABCMeta):
             e.post_init()
 
     def fill_device(self, elements: list[Element]):
-        raise PyAMLException("ElementHolder.fill_device() is not subclassed")
+        for element in elements:
+            element.fill_device(self)
+
+    @abstractmethod
+    def fill_magnet(self, magnet: Magnet) -> None:
+        pass
+
+    @abstractmethod
+    def fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
+        pass
+
+    @abstractmethod
+    def fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
+        pass
+
+    @abstractmethod
+    def fill_bpm(self, bpm: BPM) -> None:
+        pass
+
+    @abstractmethod
+    def fill_rf_plant(self, rf_plant: RFPlant) -> None:
+        pass
+
+    @abstractmethod
+    def fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
+        pass
+
+    @abstractmethod
+    def fill_tool(self, tool: "TuningTool | MeasurementTool") -> None:
+        pass
+
+    @abstractmethod
+    def fill_unbound_element(self, element: "UnboundElement") -> None:
+        pass
 
     # Aggregators
 

--- a/pyaml/common/holders/element_holder.py
+++ b/pyaml/common/holders/element_holder.py
@@ -143,7 +143,7 @@ class ElementHolder(metaclass=ABCMeta):
         for e in self.get_all_elements():
             e.post_init()
 
-    def _fill_device(self, elements: list[Element]):
+    def fill_device(self, elements: list[Element]):
         for element in elements:
             element._fill_device(self)
 

--- a/pyaml/common/holders/element_holder.py
+++ b/pyaml/common/holders/element_holder.py
@@ -143,7 +143,7 @@ class ElementHolder(metaclass=ABCMeta):
         for e in self.get_all_elements():
             e.post_init()
 
-    def fill_device(self, elements: list[Element]):
+    def _fill_device(self, elements: list[Element]):
         for element in elements:
             element._fill_device(self)
 

--- a/pyaml/common/holders/element_holder.py
+++ b/pyaml/common/holders/element_holder.py
@@ -33,14 +33,17 @@ from .sub_holders import (
 
 if TYPE_CHECKING:
     from ...accelerator import Accelerator
+    from ...configuration.unbound_element import UnboundElement
     from ...tuning_tools.bba import BBA
     from ...tuning_tools.chromaticity import Chromaticity
     from ...tuning_tools.chromaticity_response_matrix import ChromaticityResponseMatrix
     from ...tuning_tools.dispersion import Dispersion
+    from ...tuning_tools.measurement_tool import MeasurementTool
     from ...tuning_tools.orbit import Orbit
     from ...tuning_tools.orbit_response_matrix import OrbitResponseMatrix
     from ...tuning_tools.tune import Tune
     from ...tuning_tools.tune_response_matrix import TuneResponseMatrix
+    from ...tuning_tools.tuning_tool import TuningTool
 
 
 class ElementHolder(metaclass=ABCMeta):
@@ -141,7 +144,40 @@ class ElementHolder(metaclass=ABCMeta):
             e.post_init()
 
     def fill_device(self, elements: list[Element]):
-        raise PyAMLException("ElementHolder.fill_device() is not subclassed")
+        for element in elements:
+            element.fill_device(self)
+
+    @abstractmethod
+    def fill_magnet(self, magnet: Magnet) -> None:
+        pass
+
+    @abstractmethod
+    def fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
+        pass
+
+    @abstractmethod
+    def fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
+        pass
+
+    @abstractmethod
+    def fill_bpm(self, bpm: BPM) -> None:
+        pass
+
+    @abstractmethod
+    def fill_rf_plant(self, rf_plant: RFPlant) -> None:
+        pass
+
+    @abstractmethod
+    def fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
+        pass
+
+    @abstractmethod
+    def fill_tool(self, tool: "TuningTool | MeasurementTool") -> None:
+        pass
+
+    @abstractmethod
+    def fill_unbound_element(self, element: "UnboundElement") -> None:
+        pass
 
     # Aggregators
 

--- a/pyaml/common/holders/element_holder.py
+++ b/pyaml/common/holders/element_holder.py
@@ -147,40 +147,40 @@ class ElementHolder(metaclass=ABCMeta):
         for e in self.get_all_elements():
             e.post_init()
 
-    def fill_device(self, elements: list[Element]):
+    def _fill_device(self, elements: list[Element]):
         for element in elements:
-            element.fill_device(self)
+            element._fill_device(self)
 
     @abstractmethod
-    def fill_magnet(self, magnet: Magnet) -> None:
+    def _fill_magnet(self, magnet: Magnet) -> None:
         pass
 
     @abstractmethod
-    def fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
+    def _fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
         pass
 
     @abstractmethod
-    def fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
+    def _fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
         pass
 
     @abstractmethod
-    def fill_bpm(self, bpm: BPM) -> None:
+    def _fill_bpm(self, bpm: BPM) -> None:
         pass
 
     @abstractmethod
-    def fill_rf_plant(self, rf_plant: RFPlant) -> None:
+    def _fill_rf_plant(self, rf_plant: RFPlant) -> None:
         pass
 
     @abstractmethod
-    def fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
+    def _fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
         pass
 
     @abstractmethod
-    def fill_tool(self, tool: "TuningTool | MeasurementTool") -> None:
+    def _fill_tool(self, tool: "TuningTool | MeasurementTool") -> None:
         pass
 
     @abstractmethod
-    def fill_unbound_element(self, element: "UnboundElement") -> None:
+    def _fill_unbound_element(self, element: "UnboundElement") -> None:
         pass
 
     # Aggregators

--- a/pyaml/common/holders/element_holder.py
+++ b/pyaml/common/holders/element_holder.py
@@ -143,40 +143,40 @@ class ElementHolder(metaclass=ABCMeta):
         for e in self.get_all_elements():
             e.post_init()
 
-    def fill_device(self, elements: list[Element]):
+    def _fill_device(self, elements: list[Element]):
         for element in elements:
-            element.fill_device(self)
+            element._fill_device(self)
 
     @abstractmethod
-    def fill_magnet(self, magnet: Magnet) -> None:
+    def _fill_magnet(self, magnet: Magnet) -> None:
         pass
 
     @abstractmethod
-    def fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
+    def _fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
         pass
 
     @abstractmethod
-    def fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
+    def _fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
         pass
 
     @abstractmethod
-    def fill_bpm(self, bpm: BPM) -> None:
+    def _fill_bpm(self, bpm: BPM) -> None:
         pass
 
     @abstractmethod
-    def fill_rf_plant(self, rf_plant: RFPlant) -> None:
+    def _fill_rf_plant(self, rf_plant: RFPlant) -> None:
         pass
 
     @abstractmethod
-    def fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
+    def _fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
         pass
 
     @abstractmethod
-    def fill_tool(self, tool: "TuningTool | MeasurementTool") -> None:
+    def _fill_tool(self, tool: "TuningTool | MeasurementTool") -> None:
         pass
 
     @abstractmethod
-    def fill_unbound_element(self, element: "UnboundElement") -> None:
+    def _fill_unbound_element(self, element: "UnboundElement") -> None:
         pass
 
     # Aggregators

--- a/pyaml/configuration/unbound_element.py
+++ b/pyaml/configuration/unbound_element.py
@@ -37,8 +37,8 @@ class UnboundElement(Element):
             self._module_name,
         )
 
-    def fill_device(self, holder) -> None:
-        holder.fill_unbound_element(self)
+    def _fill_device(self, holder) -> None:
+        holder._fill_unbound_element(self)
 
     def instantiate(self, holder) -> Element:
         """

--- a/pyaml/configuration/unbound_element.py
+++ b/pyaml/configuration/unbound_element.py
@@ -37,6 +37,9 @@ class UnboundElement(Element):
             self._module_name,
         )
 
+    def fill_device(self, holder) -> None:
+        holder.fill_unbound_element(self)
+
     def instantiate(self, holder) -> Element:
         """
         Instantiate the element represented by this UnboundElement.

--- a/pyaml/control/controlsystem.py
+++ b/pyaml/control/controlsystem.py
@@ -119,13 +119,13 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
             aggv.add_devices(devs[1])
         return [agg, aggh, aggv]
 
-    def fill_magnet(self, magnet: Magnet) -> None:
+    def _fill_magnet(self, magnet: Magnet) -> None:
         device = self.get_device_access(magnet.model.get_device_names()[0])
         current = RWHardwareScalar(magnet.model, device) if magnet.model.has_hardware() else None
         strength = RWStrengthScalar(magnet.model, device) if magnet.model.has_physics() else None
         self.magnet.add(magnet.attach(self, strength, current))
 
-    def fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
+    def _fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
         devices = self.get_devices_access(magnet.model.get_device_names())
         currents = RWHardwareArray(magnet.model, devices)
         strengths = RWStrengthArray(magnet.model, devices)
@@ -134,7 +134,7 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
         for virtual_magnet in attached_magnets[1:]:
             self.magnet.add(virtual_magnet)
 
-    def fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
+    def _fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
         devices = self.get_devices_access(magnets.model.get_device_names())
         currents = []
         strengths = []
@@ -150,7 +150,7 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
         for magnet in attached_magnets[1:]:
             self.magnet.add(magnet)
 
-    def fill_bpm(self, bpm: BPM) -> None:
+    def _fill_bpm(self, bpm: BPM) -> None:
         position_devices = self.get_devices_access(bpm.get_pos_devices())
         tilt_devices = self.get_devices_access([bpm.get_tilt_device()])
         offset_devices = self.get_devices_access(bpm.get_offset_devices())
@@ -159,7 +159,7 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
         offsets = RWBpmOffsetArray(offset_devices[0], offset_devices[1])
         self.bpm.add(bpm.attach(self, positions, offsets, tilt))
 
-    def fill_rf_plant(self, rf_plant: RFPlant) -> None:
+    def _fill_rf_plant(self, rf_plant: RFPlant) -> None:
         attached_transmitters: list[RFTransmitter] = []
         if rf_plant.transmitters:
             for transmitter in rf_plant.transmitters:
@@ -175,14 +175,14 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
         voltage = RWTotalVoltage(attached_transmitters) if rf_plant.transmitters else None
         self.rf.add(rf_plant.attach(self, frequency, voltage))
 
-    def fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
+    def _fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
         devices = self.get_devices_access([monitor.tune_h, monitor.tune_v])
         self.add_betatron_tune_monitor(monitor.attach(self, RBetatronTuneArray(monitor, devices)))
 
-    def fill_tool(self, tool: TuningTool | MeasurementTool) -> None:
+    def _fill_tool(self, tool: TuningTool | MeasurementTool) -> None:
         self.add_tool(tool.attach(self))
 
-    def fill_unbound_element(self, element: UnboundElement) -> None:
+    def _fill_unbound_element(self, element: UnboundElement) -> None:
         if self.name() not in element._control_modes:
             return
         attached_element = element.instantiate(self)

--- a/pyaml/control/controlsystem.py
+++ b/pyaml/control/controlsystem.py
@@ -118,100 +118,77 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
             aggv.add_devices(devs[1])
         return [agg, aggh, aggv]
 
-    def fill_device(self, elements: list[Element]):
-        """
-        Fill device of this control system with Element
-        coming from the configuration file
+    def _fill_magnet(self, magnet: Magnet) -> None:
+        device = self.get_device_access(magnet.model.get_device_names()[0])
+        current = RWHardwareScalar(magnet.model, device) if magnet.model.has_hardware() else None
+        strength = RWStrengthScalar(magnet.model, device) if magnet.model.has_physics() else None
+        self.magnet.add(magnet.attach(self, strength, current))
 
-        Parameters
-        ----------
-        elements : list[Element]
-            List of elements coming from the configuration
-            file to attach to this control system
-        """
-        for e in elements:
-            if isinstance(e, Magnet):
-                dev = self.get_device_access(e.model.get_device_names()[0])
-                current = RWHardwareScalar(e.model, dev) if e.model.has_hardware() else None
-                strength = RWStrengthScalar(e.model, dev) if e.model.has_physics() else None
-                # Create a unique ref for this control system
-                m = e.attach(self, strength, current)
-                self.magnet.add(m)
+    def _fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
+        devices = self.get_devices_access(magnet.model.get_device_names())
+        currents = RWHardwareArray(magnet.model, devices)
+        strengths = RWStrengthArray(magnet.model, devices)
+        attached_magnets = magnet.attach(self, strengths, currents)
+        self.combined_function_magnet.add(attached_magnets[0])
+        for virtual_magnet in attached_magnets[1:]:
+            self.magnet.add(virtual_magnet)
 
-            elif isinstance(e, CombinedFunctionMagnet):
-                devs = self.get_devices_access(e.model.get_device_names())
-                currents = RWHardwareArray(e.model, devs)
-                strengths = RWStrengthArray(e.model, devs)
-                # Create unique refs the cfm and
-                # each of its function for this control system
-                ms = e.attach(self, strengths, currents)
-                self.combined_function_magnet.add(ms[0])
-                for m in ms[1:]:
-                    self.magnet.add(m)
+    def _fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
+        devices = self.get_devices_access(magnets.model.get_device_names())
+        currents = []
+        strengths = []
+        for index in range(magnets.get_nb_magnets()):
+            currents.append(
+                RWHardwareScalar(magnets.model.get_sub_model(index), devices[index]) if magnets.model.has_hardware() else None
+            )
+            strengths.append(
+                RWStrengthScalar(magnets.model.get_sub_model(index), devices[index]) if magnets.model.has_physics() else None
+            )
+        attached_magnets = magnets.attach(self, strengths, currents)
+        self.serialized_magnet.add(attached_magnets[0])
+        for magnet in attached_magnets[1:]:
+            self.magnet.add(magnet)
 
-            elif isinstance(e, SerializedMagnets):
-                devs = self.get_devices_access(e.model.get_device_names())
-                currents = []
-                strengths = []
-                # Create unique refs the series and each of its function for this
-                # control system
-                for i in range(e.get_nb_magnets()):
-                    current = RWHardwareScalar(e.model.get_sub_model(i), devs[i]) if e.model.has_hardware() else None
-                    strength = RWStrengthScalar(e.model.get_sub_model(i), devs[i]) if e.model.has_physics() else None
-                    currents.append(current)
-                    strengths.append(strength)
-                ms = e.attach(self, strengths, currents)
-                self.serialized_magnet.add(ms[0])
-                for m in ms[1:]:
-                    self.magnet.add(m)
+    def _fill_bpm(self, bpm: BPM) -> None:
+        position_devices = self.get_devices_access(bpm.get_pos_devices())
+        tilt_devices = self.get_devices_access([bpm.get_tilt_device()])
+        offset_devices = self.get_devices_access(bpm.get_offset_devices())
+        positions = RBpmArray(position_devices[0], position_devices[1])
+        tilt = RWBpmTiltScalar(tilt_devices[0])
+        offsets = RWBpmOffsetArray(offset_devices[0], offset_devices[1])
+        self.bpm.add(bpm.attach(self, positions, offsets, tilt))
 
-            elif isinstance(e, BPM):
-                pos_devs = self.get_devices_access(e.get_pos_devices())
-                tilt_devs = self.get_devices_access([e.get_tilt_device()])
-                offset_devs = self.get_devices_access(e.get_offset_devices())
-                positions = RBpmArray(pos_devs[0], pos_devs[1])
-                tilt = RWBpmTiltScalar(tilt_devs[0])
-                offsets = RWBpmOffsetArray(offset_devs[0], offset_devs[1])
-                e = e.attach(self, positions, offsets, tilt)
-                self.bpm.add(e)
+    def _fill_rf_plant(self, rf_plant: RFPlant) -> None:
+        attached_transmitters: list[RFTransmitter] = []
+        if rf_plant.transmitters:
+            for transmitter in rf_plant.transmitters:
+                voltage_device = self.get_device_access(transmitter.voltage_name)
+                phase_device = self.get_device_access(transmitter.phase_name)
+                voltage = RWRFVoltageScalar(transmitter, voltage_device)
+                phase = RWRFPhaseScalar(transmitter, phase_device)
+                attached_transmitter = transmitter.attach(self, voltage, phase)
+                self.rf.transmitter.add(attached_transmitter)
+                attached_transmitters.append(attached_transmitter)
+        frequency_device = self.get_device_access(rf_plant.masterclock)
+        frequency = RWRFFrequencyScalar(rf_plant, frequency_device)
+        voltage = RWTotalVoltage(attached_transmitters) if rf_plant.transmitters else None
+        self.rf.add(rf_plant.attach(self, frequency, voltage))
 
-            elif isinstance(e, RFPlant):
-                attachedTrans: list[RFTransmitter] = []
-                if e.transmitters:
-                    for t in e.transmitters:
-                        vDev = self.get_device_access(t.voltage_name)
-                        pDev = self.get_device_access(t.phase_name)
-                        voltage = RWRFVoltageScalar(t, vDev)
-                        phase = RWRFPhaseScalar(t, pDev)
-                        nt = t.attach(self, voltage, phase)
-                        self.rf.transmitter.add(nt)
-                        attachedTrans.append(nt)
+    def _fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
+        devices = self.get_devices_access([monitor.tune_h, monitor.tune_v])
+        self.add_betatron_tune_monitor(monitor.attach(self, RBetatronTuneArray(monitor, devices)))
 
-                fDev = self.get_device_access(e.masterclock)
-                frequency = RWRFFrequencyScalar(e, fDev)
-                voltage = RWTotalVoltage(attachedTrans) if e.transmitters else None
-                ne = e.attach(self, frequency, voltage)
-                self.rf.add(ne)
+    def _fill_tool(self, tool: TuningTool | MeasurementTool) -> None:
+        self.add_tool(tool.attach(self))
 
-            elif isinstance(e, BetatronTuneMonitor):
-                # Built in tune monitor
-                tuneDevs = self.get_devices_access([e.tune_h, e.tune_v])
-                betatron_tune = RBetatronTuneArray(e, tuneDevs)
-                e = e.attach(self, betatron_tune)
-                self.add_betatron_tune_monitor(e)
-
-            elif isinstance(e, TuningTool) | isinstance(e, MeasurementTool):
-                self.add_tool(e.attach(self))
-
-            elif isinstance(e, UnboundElement):
-                if self.name() in e._control_modes:
-                    ne = e.instantiate(self)
-
-                    if isinstance(ne, ABetatronTuneMonitor):
-                        self.add_betatron_tune_monitor(ne)
-                    else:
-                        # Default to standard Element
-                        self.add_element(ne)
+    def _fill_unbound_element(self, element: UnboundElement) -> None:
+        if self.name() not in element._control_modes:
+            return
+        attached_element = element.instantiate(self)
+        if isinstance(attached_element, ABetatronTuneMonitor):
+            self.add_betatron_tune_monitor(attached_element)
+        else:
+            self.add_element(attached_element)
 
 
 class ControlSystemAdapter(ControlSystem):

--- a/pyaml/control/controlsystem.py
+++ b/pyaml/control/controlsystem.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel
 from ..bpm.bpm import BPM
 from ..common.abstract import RWMapper
 from ..common.abstract_aggregator import ScalarAggregator
-from ..common.element import Element
 from ..common.exception import PyAMLException
 from ..common.holders.element_holder import ElementHolder
 from ..configuration.unbound_element import UnboundElement
@@ -119,100 +118,77 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
             aggv.add_devices(devs[1])
         return [agg, aggh, aggv]
 
-    def fill_device(self, elements: list[Element]):
-        """
-        Fill device of this control system with Element
-        coming from the configuration file
+    def fill_magnet(self, magnet: Magnet) -> None:
+        device = self.get_device_access(magnet.model.get_device_names()[0])
+        current = RWHardwareScalar(magnet.model, device) if magnet.model.has_hardware() else None
+        strength = RWStrengthScalar(magnet.model, device) if magnet.model.has_physics() else None
+        self.magnet.add(magnet.attach(self, strength, current))
 
-        Parameters
-        ----------
-        elements : list[Element]
-            List of elements coming from the configuration
-            file to attach to this control system
-        """
-        for e in elements:
-            if isinstance(e, Magnet):
-                dev = self.get_device_access(e.model.get_device_names()[0])
-                current = RWHardwareScalar(e.model, dev) if e.model.has_hardware() else None
-                strength = RWStrengthScalar(e.model, dev) if e.model.has_physics() else None
-                # Create a unique ref for this control system
-                m = e.attach(self, strength, current)
-                self.magnet.add(m)
+    def fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
+        devices = self.get_devices_access(magnet.model.get_device_names())
+        currents = RWHardwareArray(magnet.model, devices)
+        strengths = RWStrengthArray(magnet.model, devices)
+        attached_magnets = magnet.attach(self, strengths, currents)
+        self.combined_function_magnet.add(attached_magnets[0])
+        for virtual_magnet in attached_magnets[1:]:
+            self.magnet.add(virtual_magnet)
 
-            elif isinstance(e, CombinedFunctionMagnet):
-                devs = self.get_devices_access(e.model.get_device_names())
-                currents = RWHardwareArray(e.model, devs)
-                strengths = RWStrengthArray(e.model, devs)
-                # Create unique refs the cfm and
-                # each of its function for this control system
-                ms = e.attach(self, strengths, currents)
-                self.combined_function_magnet.add(ms[0])
-                for m in ms[1:]:
-                    self.magnet.add(m)
+    def fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
+        devices = self.get_devices_access(magnets.model.get_device_names())
+        currents = []
+        strengths = []
+        for index in range(magnets.get_nb_magnets()):
+            currents.append(
+                RWHardwareScalar(magnets.model.get_sub_model(index), devices[index]) if magnets.model.has_hardware() else None
+            )
+            strengths.append(
+                RWStrengthScalar(magnets.model.get_sub_model(index), devices[index]) if magnets.model.has_physics() else None
+            )
+        attached_magnets = magnets.attach(self, strengths, currents)
+        self.serialized_magnet.add(attached_magnets[0])
+        for magnet in attached_magnets[1:]:
+            self.magnet.add(magnet)
 
-            elif isinstance(e, SerializedMagnets):
-                devs = self.get_devices_access(e.model.get_device_names())
-                currents = []
-                strengths = []
-                # Create unique refs the series and each of its function for this
-                # control system
-                for i in range(e.get_nb_magnets()):
-                    current = RWHardwareScalar(e.model.get_sub_model(i), devs[i]) if e.model.has_hardware() else None
-                    strength = RWStrengthScalar(e.model.get_sub_model(i), devs[i]) if e.model.has_physics() else None
-                    currents.append(current)
-                    strengths.append(strength)
-                ms = e.attach(self, strengths, currents)
-                self.serialized_magnet.add(ms[0])
-                for m in ms[1:]:
-                    self.magnet.add(m)
+    def fill_bpm(self, bpm: BPM) -> None:
+        position_devices = self.get_devices_access(bpm.get_pos_devices())
+        tilt_devices = self.get_devices_access([bpm.get_tilt_device()])
+        offset_devices = self.get_devices_access(bpm.get_offset_devices())
+        positions = RBpmArray(position_devices[0], position_devices[1])
+        tilt = RWBpmTiltScalar(tilt_devices[0])
+        offsets = RWBpmOffsetArray(offset_devices[0], offset_devices[1])
+        self.bpm.add(bpm.attach(self, positions, offsets, tilt))
 
-            elif isinstance(e, BPM):
-                pos_devs = self.get_devices_access(e.get_pos_devices())
-                tilt_devs = self.get_devices_access([e.get_tilt_device()])
-                offset_devs = self.get_devices_access(e.get_offset_devices())
-                positions = RBpmArray(pos_devs[0], pos_devs[1])
-                tilt = RWBpmTiltScalar(tilt_devs[0])
-                offsets = RWBpmOffsetArray(offset_devs[0], offset_devs[1])
-                e = e.attach(self, positions, offsets, tilt)
-                self.bpm.add(e)
+    def fill_rf_plant(self, rf_plant: RFPlant) -> None:
+        attached_transmitters: list[RFTransmitter] = []
+        if rf_plant.transmitters:
+            for transmitter in rf_plant.transmitters:
+                voltage_device = self.get_device_access(transmitter.voltage_name)
+                phase_device = self.get_device_access(transmitter.phase_name)
+                voltage = RWRFVoltageScalar(transmitter, voltage_device)
+                phase = RWRFPhaseScalar(transmitter, phase_device)
+                attached_transmitter = transmitter.attach(self, voltage, phase)
+                self.rf.transmitter.add(attached_transmitter)
+                attached_transmitters.append(attached_transmitter)
+        frequency_device = self.get_device_access(rf_plant.masterclock)
+        frequency = RWRFFrequencyScalar(rf_plant, frequency_device)
+        voltage = RWTotalVoltage(attached_transmitters) if rf_plant.transmitters else None
+        self.rf.add(rf_plant.attach(self, frequency, voltage))
 
-            elif isinstance(e, RFPlant):
-                attachedTrans: list[RFTransmitter] = []
-                if e.transmitters:
-                    for t in e.transmitters:
-                        vDev = self.get_device_access(t.voltage_name)
-                        pDev = self.get_device_access(t.phase_name)
-                        voltage = RWRFVoltageScalar(t, vDev)
-                        phase = RWRFPhaseScalar(t, pDev)
-                        nt = t.attach(self, voltage, phase)
-                        self.rf.transmitter.add(nt)
-                        attachedTrans.append(nt)
+    def fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
+        devices = self.get_devices_access([monitor.tune_h, monitor.tune_v])
+        self.add_betatron_tune_monitor(monitor.attach(self, RBetatronTuneArray(monitor, devices)))
 
-                fDev = self.get_device_access(e.masterclock)
-                frequency = RWRFFrequencyScalar(e, fDev)
-                voltage = RWTotalVoltage(attachedTrans) if e.transmitters else None
-                ne = e.attach(self, frequency, voltage)
-                self.rf.add(ne)
+    def fill_tool(self, tool: TuningTool | MeasurementTool) -> None:
+        self.add_tool(tool.attach(self))
 
-            elif isinstance(e, BetatronTuneMonitor):
-                # Built in tune monitor
-                tuneDevs = self.get_devices_access([e.tune_h, e.tune_v])
-                betatron_tune = RBetatronTuneArray(e, tuneDevs)
-                e = e.attach(self, betatron_tune)
-                self.add_betatron_tune_monitor(e)
-
-            elif isinstance(e, TuningTool) | isinstance(e, MeasurementTool):
-                self.add_tool(e.attach(self))
-
-            elif isinstance(e, UnboundElement):
-                if self.name() in e._control_modes:
-                    ne = e.instantiate(self)
-
-                    if isinstance(ne, ABetatronTuneMonitor):
-                        self.add_betatron_tune_monitor(ne)
-                    else:
-                        # Default to standard Element
-                        self.add_element(ne)
+    def fill_unbound_element(self, element: UnboundElement) -> None:
+        if self.name() not in element._control_modes:
+            return
+        attached_element = element.instantiate(self)
+        if isinstance(attached_element, ABetatronTuneMonitor):
+            self.add_betatron_tune_monitor(attached_element)
+        else:
+            self.add_element(attached_element)
 
 
 class ControlSystemAdapter(ControlSystem):

--- a/pyaml/control/controlsystem.py
+++ b/pyaml/control/controlsystem.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel
 from ..bpm.bpm import BPM
 from ..common.abstract import RWMapper
 from ..common.abstract_aggregator import ScalarAggregator
-from ..common.element import Element
 from ..common.exception import PyAMLException
 from ..common.holders.element_holder import ElementHolder
 from ..configuration.factory import Factory
@@ -120,100 +119,77 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
             aggv.add_devices(devs[1])
         return [agg, aggh, aggv]
 
-    def fill_device(self, elements: list[Element]):
-        """
-        Fill device of this control system with Element
-        coming from the configuration file
+    def fill_magnet(self, magnet: Magnet) -> None:
+        device = self.get_device_access(magnet.model.get_device_names()[0])
+        current = RWHardwareScalar(magnet.model, device) if magnet.model.has_hardware() else None
+        strength = RWStrengthScalar(magnet.model, device) if magnet.model.has_physics() else None
+        self.magnet.add(magnet.attach(self, strength, current))
 
-        Parameters
-        ----------
-        elements : list[Element]
-            List of elements coming from the configuration
-            file to attach to this control system
-        """
-        for e in elements:
-            if isinstance(e, Magnet):
-                dev = self.get_device_access(e.model.get_device_names()[0])
-                current = RWHardwareScalar(e.model, dev) if e.model.has_hardware() else None
-                strength = RWStrengthScalar(e.model, dev) if e.model.has_physics() else None
-                # Create a unique ref for this control system
-                m = e.attach(self, strength, current)
-                self.magnet.add(m)
+    def fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
+        devices = self.get_devices_access(magnet.model.get_device_names())
+        currents = RWHardwareArray(magnet.model, devices)
+        strengths = RWStrengthArray(magnet.model, devices)
+        attached_magnets = magnet.attach(self, strengths, currents)
+        self.combined_function_magnet.add(attached_magnets[0])
+        for virtual_magnet in attached_magnets[1:]:
+            self.magnet.add(virtual_magnet)
 
-            elif isinstance(e, CombinedFunctionMagnet):
-                devs = self.get_devices_access(e.model.get_device_names())
-                currents = RWHardwareArray(e.model, devs)
-                strengths = RWStrengthArray(e.model, devs)
-                # Create unique refs the cfm and
-                # each of its function for this control system
-                ms = e.attach(self, strengths, currents)
-                self.combined_function_magnet.add(ms[0])
-                for m in ms[1:]:
-                    self.magnet.add(m)
+    def fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
+        devices = self.get_devices_access(magnets.model.get_device_names())
+        currents = []
+        strengths = []
+        for index in range(magnets.get_nb_magnets()):
+            currents.append(
+                RWHardwareScalar(magnets.model.get_sub_model(index), devices[index]) if magnets.model.has_hardware() else None
+            )
+            strengths.append(
+                RWStrengthScalar(magnets.model.get_sub_model(index), devices[index]) if magnets.model.has_physics() else None
+            )
+        attached_magnets = magnets.attach(self, strengths, currents)
+        self.serialized_magnet.add(attached_magnets[0])
+        for magnet in attached_magnets[1:]:
+            self.magnet.add(magnet)
 
-            elif isinstance(e, SerializedMagnets):
-                devs = self.get_devices_access(e.model.get_device_names())
-                currents = []
-                strengths = []
-                # Create unique refs the series and each of its function for this
-                # control system
-                for i in range(e.get_nb_magnets()):
-                    current = RWHardwareScalar(e.model.get_sub_model(i), devs[i]) if e.model.has_hardware() else None
-                    strength = RWStrengthScalar(e.model.get_sub_model(i), devs[i]) if e.model.has_physics() else None
-                    currents.append(current)
-                    strengths.append(strength)
-                ms = e.attach(self, strengths, currents)
-                self.serialized_magnet.add(ms[0])
-                for m in ms[1:]:
-                    self.magnet.add(m)
+    def fill_bpm(self, bpm: BPM) -> None:
+        position_devices = self.get_devices_access(bpm.get_pos_devices())
+        tilt_devices = self.get_devices_access([bpm.get_tilt_device()])
+        offset_devices = self.get_devices_access(bpm.get_offset_devices())
+        positions = RBpmArray(position_devices[0], position_devices[1])
+        tilt = RWBpmTiltScalar(tilt_devices[0])
+        offsets = RWBpmOffsetArray(offset_devices[0], offset_devices[1])
+        self.bpm.add(bpm.attach(self, positions, offsets, tilt))
 
-            elif isinstance(e, BPM):
-                pos_devs = self.get_devices_access(e.get_pos_devices())
-                tilt_devs = self.get_devices_access([e.get_tilt_device()])
-                offset_devs = self.get_devices_access(e.get_offset_devices())
-                positions = RBpmArray(pos_devs[0], pos_devs[1])
-                tilt = RWBpmTiltScalar(tilt_devs[0])
-                offsets = RWBpmOffsetArray(offset_devs[0], offset_devs[1])
-                e = e.attach(self, positions, offsets, tilt)
-                self.bpm.add(e)
+    def fill_rf_plant(self, rf_plant: RFPlant) -> None:
+        attached_transmitters: list[RFTransmitter] = []
+        if rf_plant.transmitters:
+            for transmitter in rf_plant.transmitters:
+                voltage_device = self.get_device_access(transmitter.voltage_name)
+                phase_device = self.get_device_access(transmitter.phase_name)
+                voltage = RWRFVoltageScalar(transmitter, voltage_device)
+                phase = RWRFPhaseScalar(transmitter, phase_device)
+                attached_transmitter = transmitter.attach(self, voltage, phase)
+                self.rf.transmitter.add(attached_transmitter)
+                attached_transmitters.append(attached_transmitter)
+        frequency_device = self.get_device_access(rf_plant.masterclock)
+        frequency = RWRFFrequencyScalar(rf_plant, frequency_device)
+        voltage = RWTotalVoltage(attached_transmitters) if rf_plant.transmitters else None
+        self.rf.add(rf_plant.attach(self, frequency, voltage))
 
-            elif isinstance(e, RFPlant):
-                attachedTrans: list[RFTransmitter] = []
-                if e.transmitters:
-                    for t in e.transmitters:
-                        vDev = self.get_device_access(t.voltage_name)
-                        pDev = self.get_device_access(t.phase_name)
-                        voltage = RWRFVoltageScalar(t, vDev)
-                        phase = RWRFPhaseScalar(t, pDev)
-                        nt = t.attach(self, voltage, phase)
-                        self.rf.transmitter.add(nt)
-                        attachedTrans.append(nt)
+    def fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
+        devices = self.get_devices_access([monitor.tune_h, monitor.tune_v])
+        self.add_betatron_tune_monitor(monitor.attach(self, RBetatronTuneArray(monitor, devices)))
 
-                fDev = self.get_device_access(e.masterclock)
-                frequency = RWRFFrequencyScalar(e, fDev)
-                voltage = RWTotalVoltage(attachedTrans) if e.transmitters else None
-                ne = e.attach(self, frequency, voltage)
-                self.rf.add(ne)
+    def fill_tool(self, tool: TuningTool | MeasurementTool) -> None:
+        self.add_tool(tool.attach(self))
 
-            elif isinstance(e, BetatronTuneMonitor):
-                # Built in tune monitor
-                tuneDevs = self.get_devices_access([e.tune_h, e.tune_v])
-                betatron_tune = RBetatronTuneArray(e, tuneDevs)
-                e = e.attach(self, betatron_tune)
-                self.add_betatron_tune_monitor(e)
-
-            elif isinstance(e, TuningTool) | isinstance(e, MeasurementTool):
-                self.add_tool(e.attach(self))
-
-            elif isinstance(e, UnboundElement):
-                if self.name() in e._control_modes:
-                    ne = e.instantiate(self)
-
-                    if isinstance(ne, ABetatronTuneMonitor):
-                        self.add_betatron_tune_monitor(ne)
-                    else:
-                        # Default to standard Element
-                        self.add_element(ne)
+    def fill_unbound_element(self, element: UnboundElement) -> None:
+        if self.name() not in element._control_modes:
+            return
+        attached_element = element.instantiate(self)
+        if isinstance(attached_element, ABetatronTuneMonitor):
+            self.add_betatron_tune_monitor(attached_element)
+        else:
+            self.add_element(attached_element)
 
 
 class ControlSystemAdapter(ControlSystem):

--- a/pyaml/control/controlsystem.py
+++ b/pyaml/control/controlsystem.py
@@ -118,77 +118,100 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
             aggv.add_devices(devs[1])
         return [agg, aggh, aggv]
 
-    def _fill_magnet(self, magnet: Magnet) -> None:
-        device = self.get_device_access(magnet.model.get_device_names()[0])
-        current = RWHardwareScalar(magnet.model, device) if magnet.model.has_hardware() else None
-        strength = RWStrengthScalar(magnet.model, device) if magnet.model.has_physics() else None
-        self.magnet.add(magnet.attach(self, strength, current))
+    def fill_device(self, elements: list[Element]):
+        """
+        Fill device of this control system with Element
+        coming from the configuration file
 
-    def _fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
-        devices = self.get_devices_access(magnet.model.get_device_names())
-        currents = RWHardwareArray(magnet.model, devices)
-        strengths = RWStrengthArray(magnet.model, devices)
-        attached_magnets = magnet.attach(self, strengths, currents)
-        self.combined_function_magnet.add(attached_magnets[0])
-        for virtual_magnet in attached_magnets[1:]:
-            self.magnet.add(virtual_magnet)
+        Parameters
+        ----------
+        elements : list[Element]
+            List of elements coming from the configuration
+            file to attach to this control system
+        """
+        for e in elements:
+            if isinstance(e, Magnet):
+                dev = self.get_device_access(e.model.get_device_names()[0])
+                current = RWHardwareScalar(e.model, dev) if e.model.has_hardware() else None
+                strength = RWStrengthScalar(e.model, dev) if e.model.has_physics() else None
+                # Create a unique ref for this control system
+                m = e.attach(self, strength, current)
+                self.magnet.add(m)
 
-    def _fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
-        devices = self.get_devices_access(magnets.model.get_device_names())
-        currents = []
-        strengths = []
-        for index in range(magnets.get_nb_magnets()):
-            currents.append(
-                RWHardwareScalar(magnets.model.get_sub_model(index), devices[index]) if magnets.model.has_hardware() else None
-            )
-            strengths.append(
-                RWStrengthScalar(magnets.model.get_sub_model(index), devices[index]) if magnets.model.has_physics() else None
-            )
-        attached_magnets = magnets.attach(self, strengths, currents)
-        self.serialized_magnet.add(attached_magnets[0])
-        for magnet in attached_magnets[1:]:
-            self.magnet.add(magnet)
+            elif isinstance(e, CombinedFunctionMagnet):
+                devs = self.get_devices_access(e.model.get_device_names())
+                currents = RWHardwareArray(e.model, devs)
+                strengths = RWStrengthArray(e.model, devs)
+                # Create unique refs the cfm and
+                # each of its function for this control system
+                ms = e.attach(self, strengths, currents)
+                self.combined_function_magnet.add(ms[0])
+                for m in ms[1:]:
+                    self.magnet.add(m)
 
-    def _fill_bpm(self, bpm: BPM) -> None:
-        position_devices = self.get_devices_access(bpm.get_pos_devices())
-        tilt_devices = self.get_devices_access([bpm.get_tilt_device()])
-        offset_devices = self.get_devices_access(bpm.get_offset_devices())
-        positions = RBpmArray(position_devices[0], position_devices[1])
-        tilt = RWBpmTiltScalar(tilt_devices[0])
-        offsets = RWBpmOffsetArray(offset_devices[0], offset_devices[1])
-        self.bpm.add(bpm.attach(self, positions, offsets, tilt))
+            elif isinstance(e, SerializedMagnets):
+                devs = self.get_devices_access(e.model.get_device_names())
+                currents = []
+                strengths = []
+                # Create unique refs the series and each of its function for this
+                # control system
+                for i in range(e.get_nb_magnets()):
+                    current = RWHardwareScalar(e.model.get_sub_model(i), devs[i]) if e.model.has_hardware() else None
+                    strength = RWStrengthScalar(e.model.get_sub_model(i), devs[i]) if e.model.has_physics() else None
+                    currents.append(current)
+                    strengths.append(strength)
+                ms = e.attach(self, strengths, currents)
+                self.serialized_magnet.add(ms[0])
+                for m in ms[1:]:
+                    self.magnet.add(m)
 
-    def _fill_rf_plant(self, rf_plant: RFPlant) -> None:
-        attached_transmitters: list[RFTransmitter] = []
-        if rf_plant.transmitters:
-            for transmitter in rf_plant.transmitters:
-                voltage_device = self.get_device_access(transmitter.voltage_name)
-                phase_device = self.get_device_access(transmitter.phase_name)
-                voltage = RWRFVoltageScalar(transmitter, voltage_device)
-                phase = RWRFPhaseScalar(transmitter, phase_device)
-                attached_transmitter = transmitter.attach(self, voltage, phase)
-                self.rf.transmitter.add(attached_transmitter)
-                attached_transmitters.append(attached_transmitter)
-        frequency_device = self.get_device_access(rf_plant.masterclock)
-        frequency = RWRFFrequencyScalar(rf_plant, frequency_device)
-        voltage = RWTotalVoltage(attached_transmitters) if rf_plant.transmitters else None
-        self.rf.add(rf_plant.attach(self, frequency, voltage))
+            elif isinstance(e, BPM):
+                pos_devs = self.get_devices_access(e.get_pos_devices())
+                tilt_devs = self.get_devices_access([e.get_tilt_device()])
+                offset_devs = self.get_devices_access(e.get_offset_devices())
+                positions = RBpmArray(pos_devs[0], pos_devs[1])
+                tilt = RWBpmTiltScalar(tilt_devs[0])
+                offsets = RWBpmOffsetArray(offset_devs[0], offset_devs[1])
+                e = e.attach(self, positions, offsets, tilt)
+                self.bpm.add(e)
 
-    def _fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
-        devices = self.get_devices_access([monitor.tune_h, monitor.tune_v])
-        self.add_betatron_tune_monitor(monitor.attach(self, RBetatronTuneArray(monitor, devices)))
+            elif isinstance(e, RFPlant):
+                attachedTrans: list[RFTransmitter] = []
+                if e.transmitters:
+                    for t in e.transmitters:
+                        vDev = self.get_device_access(t.voltage_name)
+                        pDev = self.get_device_access(t.phase_name)
+                        voltage = RWRFVoltageScalar(t, vDev)
+                        phase = RWRFPhaseScalar(t, pDev)
+                        nt = t.attach(self, voltage, phase)
+                        self.rf.transmitter.add(nt)
+                        attachedTrans.append(nt)
 
-    def _fill_tool(self, tool: TuningTool | MeasurementTool) -> None:
-        self.add_tool(tool.attach(self))
+                fDev = self.get_device_access(e.masterclock)
+                frequency = RWRFFrequencyScalar(e, fDev)
+                voltage = RWTotalVoltage(attachedTrans) if e.transmitters else None
+                ne = e.attach(self, frequency, voltage)
+                self.rf.add(ne)
 
-    def _fill_unbound_element(self, element: UnboundElement) -> None:
-        if self.name() not in element._control_modes:
-            return
-        attached_element = element.instantiate(self)
-        if isinstance(attached_element, ABetatronTuneMonitor):
-            self.add_betatron_tune_monitor(attached_element)
-        else:
-            self.add_element(attached_element)
+            elif isinstance(e, BetatronTuneMonitor):
+                # Built in tune monitor
+                tuneDevs = self.get_devices_access([e.tune_h, e.tune_v])
+                betatron_tune = RBetatronTuneArray(e, tuneDevs)
+                e = e.attach(self, betatron_tune)
+                self.add_betatron_tune_monitor(e)
+
+            elif isinstance(e, TuningTool) | isinstance(e, MeasurementTool):
+                self.add_tool(e.attach(self))
+
+            elif isinstance(e, UnboundElement):
+                if self.name() in e._control_modes:
+                    ne = e.instantiate(self)
+
+                    if isinstance(ne, ABetatronTuneMonitor):
+                        self.add_betatron_tune_monitor(ne)
+                    else:
+                        # Default to standard Element
+                        self.add_element(ne)
 
 
 class ControlSystemAdapter(ControlSystem):

--- a/pyaml/control/controlsystem.py
+++ b/pyaml/control/controlsystem.py
@@ -118,13 +118,13 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
             aggv.add_devices(devs[1])
         return [agg, aggh, aggv]
 
-    def fill_magnet(self, magnet: Magnet) -> None:
+    def _fill_magnet(self, magnet: Magnet) -> None:
         device = self.get_device_access(magnet.model.get_device_names()[0])
         current = RWHardwareScalar(magnet.model, device) if magnet.model.has_hardware() else None
         strength = RWStrengthScalar(magnet.model, device) if magnet.model.has_physics() else None
         self.magnet.add(magnet.attach(self, strength, current))
 
-    def fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
+    def _fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
         devices = self.get_devices_access(magnet.model.get_device_names())
         currents = RWHardwareArray(magnet.model, devices)
         strengths = RWStrengthArray(magnet.model, devices)
@@ -133,7 +133,7 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
         for virtual_magnet in attached_magnets[1:]:
             self.magnet.add(virtual_magnet)
 
-    def fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
+    def _fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
         devices = self.get_devices_access(magnets.model.get_device_names())
         currents = []
         strengths = []
@@ -149,7 +149,7 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
         for magnet in attached_magnets[1:]:
             self.magnet.add(magnet)
 
-    def fill_bpm(self, bpm: BPM) -> None:
+    def _fill_bpm(self, bpm: BPM) -> None:
         position_devices = self.get_devices_access(bpm.get_pos_devices())
         tilt_devices = self.get_devices_access([bpm.get_tilt_device()])
         offset_devices = self.get_devices_access(bpm.get_offset_devices())
@@ -158,7 +158,7 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
         offsets = RWBpmOffsetArray(offset_devices[0], offset_devices[1])
         self.bpm.add(bpm.attach(self, positions, offsets, tilt))
 
-    def fill_rf_plant(self, rf_plant: RFPlant) -> None:
+    def _fill_rf_plant(self, rf_plant: RFPlant) -> None:
         attached_transmitters: list[RFTransmitter] = []
         if rf_plant.transmitters:
             for transmitter in rf_plant.transmitters:
@@ -174,14 +174,14 @@ class ControlSystem(ElementHolder, metaclass=ABCMeta):
         voltage = RWTotalVoltage(attached_transmitters) if rf_plant.transmitters else None
         self.rf.add(rf_plant.attach(self, frequency, voltage))
 
-    def fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
+    def _fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
         devices = self.get_devices_access([monitor.tune_h, monitor.tune_v])
         self.add_betatron_tune_monitor(monitor.attach(self, RBetatronTuneArray(monitor, devices)))
 
-    def fill_tool(self, tool: TuningTool | MeasurementTool) -> None:
+    def _fill_tool(self, tool: TuningTool | MeasurementTool) -> None:
         self.add_tool(tool.attach(self))
 
-    def fill_unbound_element(self, element: UnboundElement) -> None:
+    def _fill_unbound_element(self, element: UnboundElement) -> None:
         if self.name() not in element._control_modes:
             return
         attached_element = element.instantiate(self)

--- a/pyaml/diagnostics/tune_monitor.py
+++ b/pyaml/diagnostics/tune_monitor.py
@@ -53,6 +53,9 @@ class BetatronTuneMonitor(Element, DynamicValidation, ABetatronTuneMonitor):
     def set_harmonic(self, h: int):
         self._h = float(h)
 
+    def fill_device(self, holder) -> None:
+        holder.fill_betatron_tune_monitor(self)
+
     @property
     def tune_h(self) -> str | None:
         return self._tune_h

--- a/pyaml/diagnostics/tune_monitor.py
+++ b/pyaml/diagnostics/tune_monitor.py
@@ -53,8 +53,8 @@ class BetatronTuneMonitor(Element, DynamicValidation, ABetatronTuneMonitor):
     def set_harmonic(self, h: int):
         self._h = float(h)
 
-    def fill_device(self, holder) -> None:
-        holder.fill_betatron_tune_monitor(self)
+    def _fill_device(self, holder) -> None:
+        holder._fill_betatron_tune_monitor(self)
 
     @property
     def tune_h(self) -> str | None:

--- a/pyaml/lattice/simulator.py
+++ b/pyaml/lattice/simulator.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import at
 
@@ -39,6 +40,9 @@ from ..tuning_tools.measurement_tool import MeasurementTool
 from ..tuning_tools.tuning_tool import TuningTool
 from ..validation import DynamicValidation, register_schema
 from .lattice_elements_linker import LatticeElementsLinker
+
+if TYPE_CHECKING:
+    from ..configuration.unbound_element import UnboundElement
 
 # Define the main class name for this module
 PYAMLCLASS = "Simulator"
@@ -147,124 +151,97 @@ class Simulator(ElementHolder, DynamicValidation):
             aggv.add_elem(e)
         return [agg, aggh, aggv]
 
-    def fill_device(self, elements: list[Element]):
-        for e in elements:
-            # Need conversion to physics unit to work with simulator
-            if isinstance(e, Magnet):
-                current = RWHardwareScalar(self.get_at_elems(e), e.polynom, e.model) if e.model.has_physics() else None
-                strength = RWStrengthScalar(self.get_at_elems(e), e.polynom, e.model) if e.model.has_physics() else None
-                # Create a unique ref for this simulator
-                m = e.attach(self, strength, current)
-                self.magnet.add(m)
+    def fill_magnet(self, magnet: Magnet) -> None:
+        current = (
+            RWHardwareScalar(self.get_at_elems(magnet), magnet.polynom, magnet.model) if magnet.model.has_physics() else None
+        )
+        strength = (
+            RWStrengthScalar(self.get_at_elems(magnet), magnet.polynom, magnet.model) if magnet.model.has_physics() else None
+        )
+        self.magnet.add(magnet.attach(self, strength, current))
 
-            elif isinstance(e, CombinedFunctionMagnet):
-                currents = RWHardwareArray(self.get_at_elems(e), e.polynoms, e.model) if e.model.has_physics() else None
-                strengths = RWStrengthArray(self.get_at_elems(e), e.polynoms, e.model) if e.model.has_physics() else None
-                # Create unique refs of each function for this simulator
-                ms = e.attach(self, strengths, currents)
-                self.combined_function_magnet.add(ms[0])
-                for m in ms[1:]:
-                    self.magnet.add(m)
+    def fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
+        currents = (
+            RWHardwareArray(self.get_at_elems(magnet), magnet.polynoms, magnet.model) if magnet.model.has_physics() else None
+        )
+        strengths = (
+            RWStrengthArray(self.get_at_elems(magnet), magnet.polynoms, magnet.model) if magnet.model.has_physics() else None
+        )
+        magnets = magnet.attach(self, strengths, currents)
+        self.combined_function_magnet.add(magnets[0])
+        for virtual_magnet in magnets[1:]:
+            self.magnet.add(virtual_magnet)
 
-            elif isinstance(e, SerializedMagnets):
-                currents = []
-                strengths = []
-                # Create unique refs the series and each of its function for this
-                # control system
-                # Link hardware to strengths and bind strength together
-                for index, magnet in enumerate(e.get_magnets()):
-                    current = (
-                        RWHardwareScalar(
-                            self.get_at_elems(magnet),
-                            e.polynom,
-                            e.model.get_sub_model(index),
-                        )
-                        if e.model.has_hardware()
-                        else None
-                    )
-                    strength = (
-                        RWStrengthScalar(
-                            self.get_at_elems(magnet),
-                            e.polynom,
-                            e.model.get_sub_model(index),
-                        )
-                        if e.model.has_physics()
-                        else None
-                    )
-                    currents.append(current)
-                    strengths.append(strength)
-                linked_currents = []
-                linked_strengths = []
-                for i in range(e.get_nb_magnets()):
-                    current = RWSerializedHardware(currents, i) if e.model.has_hardware() else None
-                    strength = RWSerializedStrength(strengths, currents, i) if e.model.has_physics() else None
-                    linked_currents.append(current)
-                    linked_strengths.append(strength)
-                ms = e.attach(self, linked_strengths, linked_currents)
-                self.serialized_magnet.add(ms[0])
-                for m in ms[1:]:
-                    self.magnet.add(m)
+    def fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
+        currents = []
+        strengths = []
+        for index, magnet in enumerate(magnets.get_magnets()):
+            current = (
+                RWHardwareScalar(self.get_at_elems(magnet), magnets.polynom, magnets.model.get_sub_model(index))
+                if magnets.model.has_hardware()
+                else None
+            )
+            strength = (
+                RWStrengthScalar(self.get_at_elems(magnet), magnets.polynom, magnets.model.get_sub_model(index))
+                if magnets.model.has_physics()
+                else None
+            )
+            currents.append(current)
+            strengths.append(strength)
+        linked_currents = []
+        linked_strengths = []
+        for index in range(magnets.get_nb_magnets()):
+            linked_currents.append(RWSerializedHardware(currents, index) if magnets.model.has_hardware() else None)
+            linked_strengths.append(RWSerializedStrength(strengths, currents, index) if magnets.model.has_physics() else None)
+        attached_magnets = magnets.attach(self, linked_strengths, linked_currents)
+        self.serialized_magnet.add(attached_magnets[0])
+        for magnet in attached_magnets[1:]:
+            self.magnet.add(magnet)
 
-            elif isinstance(e, BPM):
-                # This assumes unique BPM names in the pyAT lattice
+    def fill_bpm(self, bpm: BPM) -> None:
+        bpm_elt = self.get_at_elems(bpm)[0]
+        if not hasattr(bpm_elt, "Tilt"):
+            bpm_elt.Tilt = 0.0
+        if not hasattr(bpm_elt, "Offset"):
+            bpm_elt.Offset = [0.0, 0.0]
+        if len(bpm_elt.Offset) != 2:
+            raise PyAMLException(f"BPM {bpm.get_name()} offset must be a 2-element array.")
+        update_bpm_transform_matrix(bpm_elt)
+        self.bpm.add(bpm.attach(self, RBpmArray(bpm_elt, self.ring), RWBpmOffsetArray(bpm_elt), RWBpmTiltScalar(bpm_elt)))
 
-                # Add Tilt and Offset fields if not present
-                bpm_elt = self.get_at_elems(e)[0]
-                if not hasattr(bpm_elt, "Tilt"):
-                    bpm_elt.Tilt = 0.0  # No tilt
-                if not hasattr(bpm_elt, "Offset"):
-                    bpm_elt.Offset = [0.0, 0.0]  # No offset
-                if len(bpm_elt.Offset) != 2:
-                    raise PyAMLException(f"BPM {e.get_name()} offset must be a 2-element array.")
-                update_bpm_transform_matrix(bpm_elt)
+    def fill_rf_plant(self, rf_plant: RFPlant) -> None:
+        if rf_plant.transmitters:
+            cavities: list[at.Element] = []
+            harmonics: list[float] = []
+            attached_transmitters: list[RFTransmitter] = []
+            for transmitter in rf_plant.transmitters:
+                transmitter_cavities: list[at.Element] = []
+                for cavity_name in transmitter.cavities:
+                    cavity = self.get_at_elems(Element(cavity_name))
+                    if len(cavity) > 1:
+                        raise PyAMLException(f"RF transmitter {transmitter.get_name()},multiple cavity definition:{{cav[0]}}")
+                    if len(cavity) == 0:
+                        raise PyAMLException(f"RF transmitter {transmitter.get_name()}, No cavity found")
+                    transmitter_cavities.append(cavity[0])
+                    harmonics.append(transmitter.harmonic)
+                voltage = RWRFVoltageScalar(transmitter_cavities)
+                phase = RWRFPhaseScalar(transmitter_cavities)
+                attached_transmitter = transmitter.attach(self, voltage, phase)
+                self.rf.transmitter.add(attached_transmitter)
+                cavities.extend(transmitter_cavities)
+                attached_transmitters.append(attached_transmitter)
+            self.rf.add(rf_plant.attach(self, RWRFFrequencyScalar(cavities, harmonics), RWTotalVoltage(attached_transmitters)))
+        else:
+            self.rf.add(rf_plant.attach(self, RWRFATFrequencyScalar(self.ring), RWRFATotalVoltageScalar(self.ring)))
 
-                tilt = RWBpmTiltScalar(bpm_elt)
-                offsets = RWBpmOffsetArray(bpm_elt)
-                positions = RBpmArray(bpm_elt, self.ring)
-                e = e.attach(self, positions, offsets, tilt)
-                self.bpm.add(e)
+    def fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
+        self.add_betatron_tune_monitor(monitor.attach(self, RBetatronTuneArray(self.ring)))
 
-            elif isinstance(e, RFPlant):
-                if e.transmitters:
-                    cavs: list[at.Element] = []
-                    harmonics: list[float] = []
-                    attachedTrans: list[RFTransmitter] = []
-                    for t in e.transmitters:
-                        cavsPerTrans: list[at.Element] = []
-                        for c in t.cavities:
-                            # Expect unique name for cavities
-                            cav = self.get_at_elems(Element(c))
-                            if len(cav) > 1:
-                                raise PyAMLException(f"RF transmitter {t.get_name()},multiple cavity definition:{{cav[0]}}")
-                            if len(cav) == 0:
-                                raise PyAMLException(f"RF transmitter {t.get_name()}, No cavity found")
-                            cavsPerTrans.append(cav[0])
-                            harmonics.append(t.harmonic)
-                        voltage = RWRFVoltageScalar(cavsPerTrans)
-                        phase = RWRFPhaseScalar(cavsPerTrans)
-                        nt = t.attach(self, voltage, phase)
-                        self.rf.transmitter.add(nt)
-                        cavs.extend(cavsPerTrans)
-                        attachedTrans.append(nt)
+    def fill_tool(self, tool: TuningTool | MeasurementTool) -> None:
+        self.add_tool(tool.attach(self))
 
-                    frequency = RWRFFrequencyScalar(cavs, harmonics)
-                    voltage = RWTotalVoltage(attachedTrans)
-                    ne = e.attach(self, frequency, voltage)
-                    self.rf.add(ne)
-                else:
-                    # No transmitter defined switch to AT methods
-                    frequency = RWRFATFrequencyScalar(self.ring)
-                    voltage = RWRFATotalVoltageScalar(self.ring)
-                    ne = e.attach(self, frequency, voltage)
-                    self.rf.add(ne)
-
-            elif isinstance(e, BetatronTuneMonitor):
-                betatron_tune = RBetatronTuneArray(self.ring)
-                e = e.attach(self, betatron_tune)
-                self.add_betatron_tune_monitor(e)
-
-            elif isinstance(e, MeasurementTool) | isinstance(e, TuningTool):
-                self.add_tool(e.attach(self))
+    def fill_unbound_element(self, element: "UnboundElement") -> None:
+        pass
 
     def get_names(self, element: Element) -> list[str] | None:
         """

--- a/pyaml/lattice/simulator.py
+++ b/pyaml/lattice/simulator.py
@@ -151,7 +151,7 @@ class Simulator(ElementHolder, DynamicValidation):
             aggv.add_elem(e)
         return [agg, aggh, aggv]
 
-    def fill_magnet(self, magnet: Magnet) -> None:
+    def _fill_magnet(self, magnet: Magnet) -> None:
         current = (
             RWHardwareScalar(self.get_at_elems(magnet), magnet.polynom, magnet.model) if magnet.model.has_physics() else None
         )
@@ -160,7 +160,7 @@ class Simulator(ElementHolder, DynamicValidation):
         )
         self.magnet.add(magnet.attach(self, strength, current))
 
-    def fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
+    def _fill_combined_function_magnet(self, magnet: CombinedFunctionMagnet) -> None:
         currents = (
             RWHardwareArray(self.get_at_elems(magnet), magnet.polynoms, magnet.model) if magnet.model.has_physics() else None
         )
@@ -172,7 +172,7 @@ class Simulator(ElementHolder, DynamicValidation):
         for virtual_magnet in magnets[1:]:
             self.magnet.add(virtual_magnet)
 
-    def fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
+    def _fill_serialized_magnets(self, magnets: SerializedMagnets) -> None:
         currents = []
         strengths = []
         for index, magnet in enumerate(magnets.get_magnets()):
@@ -198,7 +198,7 @@ class Simulator(ElementHolder, DynamicValidation):
         for magnet in attached_magnets[1:]:
             self.magnet.add(magnet)
 
-    def fill_bpm(self, bpm: BPM) -> None:
+    def _fill_bpm(self, bpm: BPM) -> None:
         bpm_elt = self.get_at_elems(bpm)[0]
         if not hasattr(bpm_elt, "Tilt"):
             bpm_elt.Tilt = 0.0
@@ -209,7 +209,7 @@ class Simulator(ElementHolder, DynamicValidation):
         update_bpm_transform_matrix(bpm_elt)
         self.bpm.add(bpm.attach(self, RBpmArray(bpm_elt, self.ring), RWBpmOffsetArray(bpm_elt), RWBpmTiltScalar(bpm_elt)))
 
-    def fill_rf_plant(self, rf_plant: RFPlant) -> None:
+    def _fill_rf_plant(self, rf_plant: RFPlant) -> None:
         if rf_plant.transmitters:
             cavities: list[at.Element] = []
             harmonics: list[float] = []
@@ -234,13 +234,13 @@ class Simulator(ElementHolder, DynamicValidation):
         else:
             self.rf.add(rf_plant.attach(self, RWRFATFrequencyScalar(self.ring), RWRFATotalVoltageScalar(self.ring)))
 
-    def fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
+    def _fill_betatron_tune_monitor(self, monitor: BetatronTuneMonitor) -> None:
         self.add_betatron_tune_monitor(monitor.attach(self, RBetatronTuneArray(self.ring)))
 
-    def fill_tool(self, tool: TuningTool | MeasurementTool) -> None:
+    def _fill_tool(self, tool: TuningTool | MeasurementTool) -> None:
         self.add_tool(tool.attach(self))
 
-    def fill_unbound_element(self, element: "UnboundElement") -> None:
+    def _fill_unbound_element(self, element: "UnboundElement") -> None:
         pass
 
     def get_names(self, element: Element) -> list[str] | None:

--- a/pyaml/magnet/cfm_magnet.py
+++ b/pyaml/magnet/cfm_magnet.py
@@ -103,8 +103,8 @@ class CombinedFunctionMagnet(Element, DynamicValidation):
             # Attach
             self._peer = peer
 
-    def fill_device(self, holder) -> None:
-        holder.fill_combined_function_magnet(self)
+    def _fill_device(self, holder) -> None:
+        holder._fill_combined_function_magnet(self)
 
     def get_model_name(self) -> str:
         """

--- a/pyaml/magnet/cfm_magnet.py
+++ b/pyaml/magnet/cfm_magnet.py
@@ -103,6 +103,9 @@ class CombinedFunctionMagnet(Element, DynamicValidation):
             # Attach
             self._peer = peer
 
+    def fill_device(self, holder) -> None:
+        holder.fill_combined_function_magnet(self)
+
     def get_model_name(self) -> str:
         """
         Returns the model name of this magnet

--- a/pyaml/magnet/magnet.py
+++ b/pyaml/magnet/magnet.py
@@ -79,8 +79,8 @@ class Magnet(Element):
         obj._peer = peer
         return obj
 
-    def fill_device(self, holder) -> None:
-        holder.fill_magnet(self)
+    def _fill_device(self, holder) -> None:
+        holder._fill_magnet(self)
 
     def set_energy(self, energy: float):
         """

--- a/pyaml/magnet/magnet.py
+++ b/pyaml/magnet/magnet.py
@@ -79,6 +79,9 @@ class Magnet(Element):
         obj._peer = peer
         return obj
 
+    def fill_device(self, holder) -> None:
+        holder.fill_magnet(self)
+
     def set_energy(self, energy: float):
         """
         Set the energy in eV to compute and set the magnet rigidity

--- a/pyaml/magnet/serialized_magnet.py
+++ b/pyaml/magnet/serialized_magnet.py
@@ -134,6 +134,9 @@ class SerializedMagnets(Element, DynamicValidation):
             # Attach
             self._peer = peer
 
+    def fill_device(self, holder) -> None:
+        holder.fill_serialized_magnets(self)
+
     def __create_virtual_magnet(self, name: str) -> Magnet:
         args = {"name": name, "model": self.model}
         virtual: Magnet = function_map[self.function](**args)

--- a/pyaml/magnet/serialized_magnet.py
+++ b/pyaml/magnet/serialized_magnet.py
@@ -134,8 +134,8 @@ class SerializedMagnets(Element, DynamicValidation):
             # Attach
             self._peer = peer
 
-    def fill_device(self, holder) -> None:
-        holder.fill_serialized_magnets(self)
+    def _fill_device(self, holder) -> None:
+        holder._fill_serialized_magnets(self)
 
     def __create_virtual_magnet(self, name: str) -> Magnet:
         args = {"name": name, "model": self.model}

--- a/pyaml/rf/rf_plant.py
+++ b/pyaml/rf/rf_plant.py
@@ -57,8 +57,8 @@ class RFPlant(Element, DynamicValidation):
         obj._peer = peer
         return obj
 
-    def fill_device(self, holder) -> None:
-        holder.fill_rf_plant(self)
+    def _fill_device(self, holder) -> None:
+        holder._fill_rf_plant(self)
 
 
 class RWTotalVoltage(abstract.ReadWriteFloatScalar):

--- a/pyaml/rf/rf_plant.py
+++ b/pyaml/rf/rf_plant.py
@@ -57,6 +57,9 @@ class RFPlant(Element, DynamicValidation):
         obj._peer = peer
         return obj
 
+    def fill_device(self, holder) -> None:
+        holder.fill_rf_plant(self)
+
 
 class RWTotalVoltage(abstract.ReadWriteFloatScalar):
     def __init__(self, transmitters: list[RFTransmitter]):

--- a/pyaml/tuning_tools/measurement_tool.py
+++ b/pyaml/tuning_tools/measurement_tool.py
@@ -27,6 +27,9 @@ class MeasurementTool(Element, metaclass=ABCMeta):
         self._peer: "ElementHolder" = None  # Peer: ControlSystem or Simulator
         self._callback: Callable = None
 
+    def fill_device(self, holder: "ElementHolder") -> None:
+        holder.fill_tool(self)
+
     def _init_measure(self, measurement_type: str | None = None):
         # Initialize measurement data
         # type is used there to be able to reload a measurement, typically a reponse matrix, using the PyAML factory.

--- a/pyaml/tuning_tools/measurement_tool.py
+++ b/pyaml/tuning_tools/measurement_tool.py
@@ -27,8 +27,8 @@ class MeasurementTool(Element, metaclass=ABCMeta):
         self._peer: "ElementHolder" = None  # Peer: ControlSystem or Simulator
         self._callback: Callable = None
 
-    def fill_device(self, holder: "ElementHolder") -> None:
-        holder.fill_tool(self)
+    def _fill_device(self, holder: "ElementHolder") -> None:
+        holder._fill_tool(self)
 
     def _init_measure(self, measurement_type: str | None = None):
         # Initialize measurement data

--- a/pyaml/tuning_tools/tuning_tool.py
+++ b/pyaml/tuning_tools/tuning_tool.py
@@ -26,6 +26,9 @@ class TuningTool(Element):
         obj._peer = peer
         return obj
 
+    def fill_device(self, holder: "ElementHolder") -> None:
+        holder.fill_tool(self)
+
     def _after_attach(self) -> None:
         """Hook for subclasses to rebind internal references after attach."""
         pass

--- a/pyaml/tuning_tools/tuning_tool.py
+++ b/pyaml/tuning_tools/tuning_tool.py
@@ -26,8 +26,8 @@ class TuningTool(Element):
         obj._peer = peer
         return obj
 
-    def fill_device(self, holder: "ElementHolder") -> None:
-        holder.fill_tool(self)
+    def _fill_device(self, holder: "ElementHolder") -> None:
+        holder._fill_tool(self)
 
     def _after_attach(self) -> None:
         """Hook for subclasses to rebind internal references after attach."""

--- a/tests/common/test_element_holder.py
+++ b/tests/common/test_element_holder.py
@@ -1,0 +1,55 @@
+from pyaml.common.element import Element
+from pyaml.common.holders.element_holder import ElementHolder
+
+
+class DispatchElement(Element):
+    def _fill_device(self, holder: ElementHolder) -> None:
+        holder.filled_elements.append(self)
+
+
+class DispatchHolder(ElementHolder):
+    def __init__(self):
+        super().__init__()
+        self.filled_elements = []
+
+    def create_magnet_strength_aggregator(self, magnets):
+        return None
+
+    def create_magnet_hardware_aggregator(self, magnets):
+        return None
+
+    def create_bpm_aggregators(self, bpms):
+        return [None, None, None]
+
+    def _fill_magnet(self, magnet) -> None:
+        raise AssertionError("Unexpected magnet dispatch")
+
+    def _fill_combined_function_magnet(self, magnet) -> None:
+        raise AssertionError("Unexpected combined-function magnet dispatch")
+
+    def _fill_serialized_magnets(self, magnets) -> None:
+        raise AssertionError("Unexpected serialized magnet dispatch")
+
+    def _fill_bpm(self, bpm) -> None:
+        raise AssertionError("Unexpected BPM dispatch")
+
+    def _fill_rf_plant(self, rf_plant) -> None:
+        raise AssertionError("Unexpected RF plant dispatch")
+
+    def _fill_betatron_tune_monitor(self, monitor) -> None:
+        raise AssertionError("Unexpected betatron tune monitor dispatch")
+
+    def _fill_tool(self, tool) -> None:
+        raise AssertionError("Unexpected tool dispatch")
+
+    def _fill_unbound_element(self, element) -> None:
+        raise AssertionError("Unexpected unbound element dispatch")
+
+
+def test_fill_device_delegates_to_elements():
+    holder = DispatchHolder()
+    elements = [DispatchElement("FIRST"), DispatchElement("SECOND")]
+
+    holder.fill_device(elements)
+
+    assert holder.filled_elements == elements


### PR DESCRIPTION
## Summary

Refactor element attachment to replace the type-based `if`/`elif` chains in
`Simulator` and `ControlSystem` with holder-specific dispatch.

`ElementHolder.fill_device()` now owns the common iteration over configured
elements. Each supported element type delegates its attachment to a dedicated
`fill_*` method implemented by the target holder.

## Changes

- Add explicit attachment delegation to magnets, combined-function magnets,
  serialized magnets, BPMs, RF plants, tune monitors, tuning tools,
  measurement tools, and unbound elements.
- Add abstract `fill_*` hooks to `ElementHolder`.
- Move the existing simulator and control-system attachment logic into their
  corresponding holder-specific methods.
- Preserve the existing `UnboundElement` behaviour:
  - `ControlSystem` instantiates it only for matching `control_modes`.
  - `Simulator` ignores it, as before.
- Preserve existing configuration formats and runtime attachment behaviour.

## Validation

- Ran the standard test suite.
- Ran the DT4ACC integration smoke test against a local twin for both
  `tango-pyaml` and `pyaml-cs-oa`.