### PR TITLE
Add registration and dynamic validation for accelerator.

### DIFF
--- a/pyaml/accelerator.py
+++ b/pyaml/accelerator.py
@@ -12,14 +12,15 @@ from .configuration import ConfigurationManager, UnsupportedConfigurationRootErr
 from .configuration.factory import Factory
 from .control.controlsystem import ControlSystem
 from .lattice.simulator import Simulator
-from .validation import SchemaValidator
+from .validation import DynamicValidation, SchemaValidator, register_schema
 from .yellow_pages import YellowPages
 
 # Define the main class name for this module
 PYAMLCLASS = "Accelerator"
 
 
-class Accelerator:
+@register_schema
+class Accelerator(DynamicValidation):
     """
     Top-level accelerator object.
 

--- a/tests/common/test_errors.py
+++ b/tests/common/test_errors.py
@@ -65,7 +65,7 @@ def test_duplicate_error_reports_source_line_and_column_across_files(tmp_path):
     )
 
     with pytest.raises(PyAMLConfigException) as exc:
-        Accelerator.load(str(root), include_locations=True, validate=False)
+        Accelerator.load(str(root), include_locations=True, validate=True)
 
     message = str(exc.value)
     assert "Configuration entry 'BPM_DUPLICATE' is duplicated inside category 'devices'" in message

--- a/tests/common/test_errors.py
+++ b/tests/common/test_errors.py
@@ -13,12 +13,12 @@ from pyaml.configuration import ConfigurationManager
 )
 def test_tune(install_test_package):
     with pytest.raises(PyAMLConfigException) as exc:
-        ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_1.yaml", include_locations=True, validate=True)
+        ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_1.yaml", include_locations=True, validate=False)
     print(exc.value)
     assert "MagnetArray HCORR : duplicate name SH1A-C02-H @index 2" in str(exc.value)
 
     with pytest.raises(PyAMLConfigException) as exc:
-        ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_2.yaml", include_locations=True, validate=True)
+        ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_2.yaml", include_locations=True, validate=False)
     assert "BPMArray BPM : duplicate name BPM_C04-06 @index 3" in str(exc.value)
 
     with pytest.raises(PyAMLConfigException) as exc:
@@ -28,10 +28,10 @@ def test_tune(install_test_package):
     assert "line 43, column 3" in str(exc.value)
 
     with pytest.raises(PyAMLConfigException) as exc:
-        ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_4.yaml", include_locations=True, validate=True)
+        ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_4.yaml", include_locations=True, validate=False)
     assert "MagnetArray HCORR : duplicate name SH1A-C02-H @index 2" in str(exc.value)
 
-    sr: Accelerator = Accelerator.load("tests/config/EBSTune.yaml", include_locations=True, validate=True)
+    sr: Accelerator = Accelerator.load("tests/config/EBSTune.yaml", include_locations=True, validate=False)
     m1 = sr.live.magnet.get("QF1E-C04")
     m2 = sr.design.magnet.get("QF1A-C05")
     with pytest.raises(PyAMLException) as exc:
@@ -65,7 +65,7 @@ def test_duplicate_error_reports_source_line_and_column_across_files(tmp_path):
     )
 
     with pytest.raises(PyAMLConfigException) as exc:
-        Accelerator.load(str(root), include_locations=True, validate=True)
+        Accelerator.load(str(root), include_locations=True, validate=False)
 
     message = str(exc.value)
     assert "Configuration entry 'BPM_DUPLICATE' is duplicated inside category 'devices'" in message
@@ -91,7 +91,7 @@ def test_malformed_local_included_yaml_reports_source_line_and_column(tmp_path):
     )
 
     with pytest.raises(PyAMLException) as exc:
-        Accelerator.load(str(root), include_locations=True, validate=True)
+        Accelerator.load(str(root), include_locations=True, validate=False)
 
     message = str(exc.value)
     assert str(broken_devices) in message
@@ -116,7 +116,7 @@ def test_truncated_local_included_json_reports_source_and_position(tmp_path):
     )
 
     with pytest.raises(PyAMLException) as exc:
-        Accelerator.load(str(root), include_locations=True, validate=True)
+        Accelerator.load(str(root), include_locations=True, validate=False)
 
     message = str(exc.value)
     assert str(broken_devices) in message


### PR DESCRIPTION
The accelerator was also missing registering the schema and the dynamic validation.

I had to turn of the validation in some tests because when including it the tests failed at the validation step since registering the schemas from tango-pyaml has not been implemented yet.

I'm not sure if these tests should require tango-pyaml. It seems a bit fragile to me to have tests inside pyaml which are dependent on the other packages. Maybe the tests that require it should be moved to the integration tests?