### PR TITLE
Add workflow for github release.

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,49 @@
+name: GitHub Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and create release on GitHub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Hatch
+        run: python -m pip install --upgrade hatch
+
+      - name: Build distribution
+        run: hatch build
+
+      - name: Determine whether this is a pre-release
+        id: release_type
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+
+          if [[ "$tag" =~ (\.dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+)$ ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v3
+        with:
+          draft: false
+          prerelease: ${{ steps.release_type.outputs.prerelease }}
+          generate_release_notes: true
+          files: dist/*


### PR DESCRIPTION
I have added a workflow to make a release on github. It's the same one as I have tested in pyaml-cs-oa. It is triggered by a tag and make pre-releases if the tag is a pre-release or development tags.

I will run in parallel to the workflow to publish on PyPI because I didn't manage to figure out how to get this workflow to trigger the other one yet.