### PR TITLE
Report real constructor signatures on `ValidationMeta` classes

### DIFF
--- a/pyaml/validation/validation_models.py
+++ b/pyaml/validation/validation_models.py
@@ -36,7 +36,41 @@ class ValidationMeta(ABCMeta):
     invoked.
 
     Pass `validate=False` to skip validation for a single construction.
+
+    The signature reported by :func:`inspect.signature` for classes using this
+    metaclass is that of their ``__init__``, not of :meth:`__call__`. The
+    ``validate`` keyword is therefore not part of the reported signature.
     """
+
+    @property
+    def __signature__(cls) -> inspect.Signature | None:
+        """
+        Report the constructor signature of the class.
+
+        Without this, :func:`inspect.signature` resolves to :meth:`__call__` and
+        reports ``(*args, **kwargs)`` for every class using this metaclass, which
+        hides the real parameters from ``help()``, Sphinx and other tooling.
+
+        Returns
+        -------
+        inspect.Signature | None
+            Signature of ``cls.__init__`` without ``self``, or ``None`` if it
+            cannot be determined, in which case the default introspection applies.
+        """
+        # Classes relying on ``object.__init__`` take no argument, as reported by
+        # ``inspect.signature`` for a class without a metaclass
+        if cls.__init__ is object.__init__ and cls.__new__ is object.__new__:
+            return inspect.Signature()
+
+        try:
+            signature = inspect.signature(cls.__init__)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            return None
+
+        # Drop ``self`` and the constructor return annotation
+        parameters = list(signature.parameters.values())[1:]
+
+        return signature.replace(parameters=parameters, return_annotation=inspect.Signature.empty)
 
     def __call__(cls, *args: Any, **kwargs: Any):
         """

--- a/tests/validation/test_models.py
+++ b/tests/validation/test_models.py
@@ -1,6 +1,8 @@
 """Tests of the configuration models."""
 
+import inspect
 import json
+from dataclasses import dataclass
 
 import pytest
 from pydantic import BaseModel, ValidationError
@@ -364,3 +366,80 @@ def test_static_validation_requires_a_validation_model():
         class Broken(StaticValidation):
             def __init__(self, name: str):
                 self.name = name
+
+
+# ==========================================================
+# ValidationMeta signatures
+# ==========================================================
+
+
+def test_dynamic_validation_exposes_constructor_signature():
+    class MyClass(DynamicValidation):
+        def __init__(self, name: str, count: int = 0):
+            self.name = name
+            self.count = count
+
+    signature = inspect.signature(MyClass)
+
+    assert list(signature.parameters) == ["name", "count"]
+    assert signature.parameters["count"].default == 0
+    assert signature.return_annotation is inspect.Signature.empty
+
+
+def test_static_validation_exposes_constructor_signature():
+    class ExampleModel(BaseModel):
+        name: str
+
+    class Example(StaticValidation):
+        validation_model = ExampleModel
+
+        def __init__(self, name: str):
+            self.name = name
+
+    assert list(inspect.signature(Example).parameters) == ["name"]
+
+
+def test_validation_signature_excludes_validate_keyword():
+    class MyClass(DynamicValidation):
+        def __init__(self, name: str):
+            self.name = name
+
+    assert "validate" not in inspect.signature(MyClass).parameters
+
+
+def test_validation_signature_uses_inherited_constructor():
+    class Parent(DynamicValidation):
+        def __init__(self, name: str, count: int = 0):
+            self.name = name
+            self.count = count
+
+    class Child(Parent):
+        pass
+
+    assert list(inspect.signature(Child).parameters) == ["name", "count"]
+
+
+def test_validation_signature_of_class_without_constructor_is_empty():
+    class MyClass(DynamicValidation):
+        pass
+
+    assert inspect.signature(MyClass) == inspect.Signature()
+
+
+def test_validation_signature_matches_dataclass_fields():
+    @dataclass
+    class MyClass(DynamicValidation):
+        name: str
+        count: int = 0
+
+    assert list(inspect.signature(MyClass).parameters) == ["name", "count"]
+
+
+def test_validation_signature_not_visible_on_instances():
+    class MyClass(DynamicValidation):
+        def __init__(self, name: str):
+            self.name = name
+
+    obj = MyClass("test")
+
+    assert not hasattr(obj, "__signature__")


### PR DESCRIPTION
Closes #387
Code fully generated by AI, I checked that the fix seem to be working but I don't really know the specifics of this part of the code.
The main choice in the fix is **not** to expose the `validate` keyword in all signature of the concerned class.

## Problem

`inspect.signature()` consults a class's metaclass `__call__` before falling back to
`__init__`. Since `ValidationMeta.__call__(cls, *args, **kwargs)` fronts every class built on
`DynamicValidation` / `StaticValidation`, **46 of the 173 pyaml classes** introspected as
`(*args, **kwargs)`:

```python
>>> inspect.signature(Quadrupole)
(*args: Any, **kwargs: Any)
```

## Change

A `__signature__` property on `ValidationMeta` returning the signature of `cls.__init__` 
without `self`. As a property on the metaclass it is a data descriptor on `type(cls)`, so it
wins the `Quadrupole.__signature__` lookup that `inspect.signature` performs before its
metaclass-`__call__` branch. Details:

- `inspect.signature(cls.__init__)` already walks the MRO, so subclasses without their own
  `__init__` get the inherited one, and the `@dataclass` classes resolve correctly.
- Classes relying on `object.__init__` report an empty signature, which is what `inspect`
  reports for a plain class.
- The `validate` keyword that `__call__` pops is deliberately **not** advertised: including it
  would make numpydoc flag `validate` as undocumented on all 46 classes. It remains documented
  in the `ValidationMeta` and `DynamicValidation` docstrings, and the `ValidationMeta` docstring
  now states that the reported signature is `__init__`'s.
- Failure to compute a signature returns `None`, which `inspect` treats as "absent", falling
  back to the previous behaviour rather than raising.
- No caching: no internal code path calls `inspect.signature(cls)`. `configuration/manager.py`,
  `validation/schema_builder.py` and `ValidationMeta.__call__` itself all go through
  `cls.__init__` explicitly and are unaffected.

No behavioural change: validation, positional/keyword binding and `validate=False` are untouched.

## Tests

Seven tests in `tests/validation/test_models.py` covering the dynamic and static branches,
inherited constructors, `@dataclass` subclasses, classes without an `__init__`, exclusion of
`validate`, and non-leakage of `__signature__` onto instances.

## Verification

| Check | Result |
|---|---|
| Sweep of all 173 pyaml classes | 0 of the 46 still report `(*args, **kwargs)` |
| `pytest tests` | 279 passed, 7 skipped |
| numpydoc over the 46 classes | `PR01` 46 → 2, `PR02` 44 → 0 |
| Sphinx HTML | `class …Quadrupole(name, model=None, lattice_names=None, description=None)` |
| `ruff format --check` / `ruff check` | clean |

The 2 remaining `PR01` are genuine: `ResponseMatrixData` and `OrbitResponseMatrixData` do not
document their `type` parameter. They are left for a separate docstring change.