### PR TITLE
Updated example

### DIFF
--- a/examples/other_examples/ControlSystem/tango/config.yaml
+++ b/examples/other_examples/ControlSystem/tango/config.yaml
@@ -10,7 +10,5 @@ data_folder: /data/store
 devices:
 - type: pyaml.bpm.bpm
   name: BPM_C01-01
-  model:
-    type: pyaml.bpm.bpm_simple_model
-    x_pos: srdiag/bpm/c01-01/SA_HPosition
-    y_pos: srdiag/bpm/c01-01/SA_VPosition
+  x_pos: srdiag/bpm/c01-01/SA_HPosition
+  y_pos: srdiag/bpm/c01-01/SA_VPosition

--- a/examples/other_examples/ControlSystem/tango/main.py
+++ b/examples/other_examples/ControlSystem/tango/main.py
@@ -3,7 +3,7 @@ from pyaml.accelerator import Accelerator
 sr = Accelerator.load("config.yaml")
 
 # print the BPM position
-bpm = sr.live.get_bpm("BPM_C01-01")  # bpm is a BPM
+bpm = sr.live.bpm.get("BPM_C01-01")  # bpm is a BPM
 print(bpm.positions.get())
 
 # Direct access to control system


### PR DESCRIPTION
This PR update ControlSystem backend implementation example with simplified BPM configuration and new holder API.

```yaml
type: pyaml.accelerator
facility: ESRF
machine: sr
energy: 6e9
controls:
  - type: tango_controlsystem
    prefix: //ebs-simu-3:10000/
    name: live
data_folder: /data/store
devices:
- type: pyaml.bpm.bpm
  name: BPM_C01-01
  x_pos: srdiag/bpm/c01-01/SA_HPosition
  y_pos: srdiag/bpm/c01-01/SA_VPosition
```

```python
from pyaml.accelerator import Accelerator

sr = Accelerator.load("config.yaml")

# print the BPM position
bpm = sr.live.bpm.get("BPM_C01-01")  # bpm is a BPM
print(bpm.positions.get())

# Direct access to control system
da = sr.live.get_device_access("srdiag/bpm/c01-01/SA_HPosition")  # da is a DeviceAccess
print(f"h={da.get()} {da.unit()}")
```

```
[-4.17893818e-07 -6.38265546e-05]
h=-4.178938175034126e-07 m
```