### PR TITLE
Change type to class in configuration files

### DIFF
--- a/examples/use_cases/config/bessy2/bessy2.yaml
+++ b/examples/use_cases/config/bessy2/bessy2.yaml
@@ -1,21 +1,21 @@
-type: pyaml.accelerator
+class: pyaml.accelerator.Accelerator
 machine: sr
 facility: BESSY2
 energy: 1.7185e9
 simulators:
-- type: pyaml.lattice.simulator
+- class: pyaml.lattice.simulator.Simulator
   lattice: bessy2_standard_user.mat
   name: design
 controls:
-- type: pyaml_cs_oa.controlsystem
+- class: pyaml_cs_oa.controlsystem.OphydAsyncControlSystem
   prefix: 'pons:'
   name: live
   catalog:
-    type: pyaml_cs_oa.dynamic_catalog
+    class: pyaml_cs_oa.dynamic_catalog.DynamicCatalog
     backend: epics
 data_folder: /data/store
 arrays:
-- type: pyaml.arrays.magnet
+- class: pyaml.arrays.magnet.Magnet
   name: HCorr
   elements:
   - HS4M2D1R
@@ -66,7 +66,7 @@ arrays:
   - HS4M2T8R
   - HS1MD1R
   - HS4M1D1R
-- type: pyaml.arrays.magnet
+- class: pyaml.arrays.magnet.Magnet
   name: VCorr
   elements:
   - VS3M2D1R
@@ -133,7 +133,7 @@ arrays:
   - VS2M2T8R
   - VS2M1D1R
   - VS3M1D1R
-- type: pyaml.arrays.bpm
+- class: pyaml.arrays.bpm.BPM
   name: BPM
   elements:
   - BPMZ5D1R
@@ -259,7 +259,7 @@ arrays:
   - BPMZ4D1R
   - BPMZ41D1R
   - BPMZ42D1R
-- type: pyaml.arrays.magnet
+- class: pyaml.arrays.magnet.Magnet
   name: QForTune
   elements:
   - Q3M2D1R
@@ -327,2118 +327,2118 @@ arrays:
   - Q4M2T8R
   - Q4M1D1R
 devices:
-- type: pyaml.tuning_tools.orbit_response_matrix
+- class: pyaml.tuning_tools.orbit_response_matrix.OrbitResponseMatrix
   bpm_array_name: BPM
   hcorr_array_name: HCorr
   vcorr_array_name: VCorr
   corrector_delta: 1e-6
   name: DEFAULT_ORBIT_RESPONSE_MATRIX
-- type: pyaml.tuning_tools.dispersion
+- class: pyaml.tuning_tools.dispersion.Dispersion
   bpm_array_name: BPM
   rf_plant_name: RF
   frequency_delta: 10
   name: DEFAULT_DISPERSION
-- type: pyaml.tuning_tools.orbit
+- class: pyaml.tuning_tools.orbit.Orbit
   bpm_array_name: BPM
   hcorr_array_name: HCorr
   vcorr_array_name: VCorr
   name: DEFAULT_ORBIT_CORRECTION
   singular_values: 16
   response_matrix: ${path:orm.json}
-- type: pyaml.rf.rf_plant
+- class: pyaml.rf.rf_plant.RFPlant
   name: RF
   masterclock: (MCLKHX251C:freq)[KHz]
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2D1R
   lattice_names: S4M2D1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2D1R:rdbk, HS4P2D1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MT1R
   lattice_names: S1MT1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PT1R:rdbk, HS1PT1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1T1R
   lattice_names: S4M1T1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1T1R:rdbk, HS4P1T1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2T1R
   lattice_names: S4M2T1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2T1R:rdbk, HS4P2T1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MD2R
   lattice_names: S1MD2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PD2R:rdbk, HS1PD2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1D2R
   lattice_names: S4M1D2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1D2R:rdbk, HS4P1D2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2D2R
   lattice_names: S4M2D2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2D2R:rdbk, HS4P2D2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MT2R
   lattice_names: S1MT2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PT2R:rdbk, HS1PT2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1T2R
   lattice_names: S4M1T2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1T2R:rdbk, HS4P1T2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2T2R
   lattice_names: S4M2T2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2T2R:rdbk, HS4P2T2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MD3R
   lattice_names: S1MD3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PD3R:rdbk, HS1PD3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1D3R
   lattice_names: S4M1D3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1D3R:rdbk, HS4P1D3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2D3R
   lattice_names: S4M2D3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2D3R:rdbk, HS4P2D3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MT3R
   lattice_names: S1MT3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PT3R:rdbk, HS1PT3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1T3R
   lattice_names: S4M1T3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1T3R:rdbk, HS4P1T3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2T3R
   lattice_names: S4M2T3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2T3R:rdbk, HS4P2T3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MD4R
   lattice_names: S1MD4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PD4R:rdbk, HS1PD4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1D4R
   lattice_names: S4M1D4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1D4R:rdbk, HS4P1D4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2D4R
   lattice_names: S4M2D4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2D4R:rdbk, HS4P2D4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MT4R
   lattice_names: S1MT4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PT4R:rdbk, HS1PT4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1T4R
   lattice_names: S4M1T4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1T4R:rdbk, HS4P1T4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2T4R
   lattice_names: S4M2T4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2T4R:rdbk, HS4P2T4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MD5R
   lattice_names: S1MD5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PD5R:rdbk, HS1PD5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1D5R
   lattice_names: S4M1D5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1D5R:rdbk, HS4P1D5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2D5R
   lattice_names: S4M2D5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2D5R:rdbk, HS4P2D5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MT5R
   lattice_names: S1MT5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PT5R:rdbk, HS1PT5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1T5R
   lattice_names: S4M1T5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1T5R:rdbk, HS4P1T5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2T5R
   lattice_names: S4M2T5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2T5R:rdbk, HS4P2T5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MD6R
   lattice_names: S1MD6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PD6R:rdbk, HS1PD6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1D6R
   lattice_names: S4M1D6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1D6R:rdbk, HS4P1D6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2D6R
   lattice_names: S4M2D6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2D6R:rdbk, HS4P2D6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MT6R
   lattice_names: S1MT6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PT6R:rdbk, HS1PT6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1T6R
   lattice_names: S4M1T6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1T6R:rdbk, HS4P1T6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2T6R
   lattice_names: S4M2T6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2T6R:rdbk, HS4P2T6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MD7R
   lattice_names: S1MD7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PD7R:rdbk, HS1PD7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1D7R
   lattice_names: S4M1D7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1D7R:rdbk, HS4P1D7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2D7R
   lattice_names: S4M2D7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2D7R:rdbk, HS4P2D7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MT7R
   lattice_names: S1MT7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PT7R:rdbk, HS1PT7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1T7R
   lattice_names: S4M1T7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1T7R:rdbk, HS4P1T7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2T7R
   lattice_names: S4M2T7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2T7R:rdbk, HS4P2T7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MD8R
   lattice_names: S1MD8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PD8R:rdbk, HS1PD8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1D8R
   lattice_names: S4M1D8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1D8R:rdbk, HS4P1D8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2D8R
   lattice_names: S4M2D8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2D8R:rdbk, HS4P2D8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MT8R
   lattice_names: S1MT8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PT8R:rdbk, HS1PT8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1T8R
   lattice_names: S4M1T8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1T8R:rdbk, HS4P1T8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M2T8R
   lattice_names: S4M2T8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P2T8R:rdbk, HS4P2T8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS1MD1R
   lattice_names: S1MD1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.00553438
     unit: 1/m
     powerconverter: (HS1PD1R:rdbk, HS1PD1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.hcorrector
+- class: pyaml.magnet.hcorrector.HCorrector
   name: HS4M1D1R
   lattice_names: S4M1D1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0044502
     unit: 1/m
     powerconverter: (HS4P1D1R:rdbk, HS4P1D1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2D1R
   lattice_names: S3M2D1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2D1R:rdbk, VS3P2D1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2D1R
   lattice_names: S2M2D1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2D1R:rdbk, VS2P2D1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1T1R
   lattice_names: S2M1T1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1T1R:rdbk, VS2P1T1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1T1R
   lattice_names: S3M1T1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1T1R:rdbk, VS3P1T1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2T1R
   lattice_names: S3M2T1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2T1R:rdbk, VS3P2T1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2T1R
   lattice_names: S2M2T1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2T1R:rdbk, VS2P2T1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1D2R
   lattice_names: S2M1D2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1D2R:rdbk, VS2P1D2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1D2R
   lattice_names: S3M1D2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1D2R:rdbk, VS3P1D2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2D2R
   lattice_names: S3M2D2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2D2R:rdbk, VS3P2D2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2D2R
   lattice_names: S2M2D2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2D2R:rdbk, VS2P2D2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1T2R
   lattice_names: S2M1T2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1T2R:rdbk, VS2P1T2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1T2R
   lattice_names: S3M1T2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1T2R:rdbk, VS3P1T2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2T2R
   lattice_names: S3M2T2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2T2R:rdbk, VS3P2T2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2T2R
   lattice_names: S2M2T2R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2T2R:rdbk, VS2P2T2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1D3R
   lattice_names: S2M1D3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1D3R:rdbk, VS2P1D3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1D3R
   lattice_names: S3M1D3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1D3R:rdbk, VS3P1D3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2D3R
   lattice_names: S3M2D3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2D3R:rdbk, VS3P2D3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2D3R
   lattice_names: S2M2D3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2D3R:rdbk, VS2P2D3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1T3R
   lattice_names: S2M1T3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1T3R:rdbk, VS2P1T3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1T3R
   lattice_names: S3M1T3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1T3R:rdbk, VS3P1T3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2T3R
   lattice_names: S3M2T3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2T3R:rdbk, VS3P2T3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2T3R
   lattice_names: S2M2T3R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2T3R:rdbk, VS2P2T3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1D4R
   lattice_names: S2M1D4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1D4R:rdbk, VS2P1D4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1D4R
   lattice_names: S3M1D4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1D4R:rdbk, VS3P1D4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2D4R
   lattice_names: S3M2D4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2D4R:rdbk, VS3P2D4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2D4R
   lattice_names: S2M2D4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2D4R:rdbk, VS2P2D4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1T4R
   lattice_names: S2M1T4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1T4R:rdbk, VS2P1T4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1T4R
   lattice_names: S3M1T4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1T4R:rdbk, VS3P1T4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2T4R
   lattice_names: S3M2T4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2T4R:rdbk, VS3P2T4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2T4R
   lattice_names: S2M2T4R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2T4R:rdbk, VS2P2T4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1D5R
   lattice_names: S2M1D5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1D5R:rdbk, VS2P1D5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1D5R
   lattice_names: S3M1D5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1D5R:rdbk, VS3P1D5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2D5R
   lattice_names: S3M2D5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2D5R:rdbk, VS3P2D5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2D5R
   lattice_names: S2M2D5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2D5R:rdbk, VS2P2D5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1T5R
   lattice_names: S2M1T5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1T5R:rdbk, VS2P1T5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1T5R
   lattice_names: S3M1T5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1T5R:rdbk, VS3P1T5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2T5R
   lattice_names: S3M2T5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2T5R:rdbk, VS3P2T5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2T5R
   lattice_names: S2M2T5R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2T5R:rdbk, VS2P2T5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1D6R
   lattice_names: S2M1D6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1D6R:rdbk, VS2P1D6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1D6R
   lattice_names: S3M1D6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1D6R:rdbk, VS3P1D6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2D6R
   lattice_names: S3M2D6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2D6R:rdbk, VS3P2D6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2D6R
   lattice_names: S2M2D6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2D6R:rdbk, VS2P2D6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1T6R
   lattice_names: S2M1T6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1T6R:rdbk, VS2P1T6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1T6R
   lattice_names: S3M1T6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1T6R:rdbk, VS3P1T6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2T6R
   lattice_names: S3M2T6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2T6R:rdbk, VS3P2T6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2T6R
   lattice_names: S2M2T6R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2T6R:rdbk, VS2P2T6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1D7R
   lattice_names: S2M1D7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1D7R:rdbk, VS2P1D7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1D7R
   lattice_names: S3M1D7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1D7R:rdbk, VS3P1D7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2D7R
   lattice_names: S3M2D7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2D7R:rdbk, VS3P2D7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2D7R
   lattice_names: S2M2D7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2D7R:rdbk, VS2P2D7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1T7R
   lattice_names: S2M1T7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1T7R:rdbk, VS2P1T7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1T7R
   lattice_names: S3M1T7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1T7R:rdbk, VS3P1T7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2T7R
   lattice_names: S3M2T7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2T7R:rdbk, VS3P2T7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2T7R
   lattice_names: S2M2T7R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2T7R:rdbk, VS2P2T7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1D8R
   lattice_names: S2M1D8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1D8R:rdbk, VS2P1D8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1D8R
   lattice_names: S3M1D8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1D8R:rdbk, VS3P1D8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2D8R
   lattice_names: S3M2D8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2D8R:rdbk, VS3P2D8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2D8R
   lattice_names: S2M2D8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2D8R:rdbk, VS2P2D8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1T8R
   lattice_names: S2M1T8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1T8R:rdbk, VS2P1T8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1T8R
   lattice_names: S3M1T8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1T8R:rdbk, VS3P1T8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M2T8R
   lattice_names: S3M2T8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P2T8R:rdbk, VS3P2T8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M2T8R
   lattice_names: S2M2T8R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P2T8R:rdbk, VS2P2T8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS2M1D1R
   lattice_names: S2M1D1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS2P1D1R:rdbk, VS2P1D1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.vcorrector
+- class: pyaml.magnet.vcorrector.VCorrector
   name: VS3M1D1R
   lattice_names: S3M1D1R@0
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.00297607
     unit: 1/m
     powerconverter: (VS3P1D1R:rdbk, VS3P1D1R:set)[A]
     hardware_unit: A
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5D1R
   x_pos: ORBITCC:rdPos@0
   y_pos: ORBITCC:rdPos@1
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6D1R
   x_pos: ORBITCC:rdPos@2
   y_pos: ORBITCC:rdPos@3
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7D1R
   x_pos: ORBITCC:rdPos@4
   y_pos: ORBITCC:rdPos@5
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1T1R
   x_pos: ORBITCC:rdPos@6
   y_pos: ORBITCC:rdPos@7
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2T1R
   x_pos: ORBITCC:rdPos@8
   y_pos: ORBITCC:rdPos@9
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3T1R
   x_pos: ORBITCC:rdPos@10
   y_pos: ORBITCC:rdPos@11
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4T1R
   x_pos: ORBITCC:rdPos@12
   y_pos: ORBITCC:rdPos@13
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ41T1R
   x_pos: ORBITCC:rdPos@14
   y_pos: ORBITCC:rdPos@15
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5T1R
   x_pos: ORBITCC:rdPos@16
   y_pos: ORBITCC:rdPos@17
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6T1R
   x_pos: ORBITCC:rdPos@18
   y_pos: ORBITCC:rdPos@19
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7T1R
   x_pos: ORBITCC:rdPos@20
   y_pos: ORBITCC:rdPos@21
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1D2R
   x_pos: ORBITCC:rdPos@22
   y_pos: ORBITCC:rdPos@23
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2D2R
   x_pos: ORBITCC:rdPos@24
   y_pos: ORBITCC:rdPos@25
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3D2R
   x_pos: ORBITCC:rdPos@26
   y_pos: ORBITCC:rdPos@27
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4D2R
   x_pos: ORBITCC:rdPos@28
   y_pos: ORBITCC:rdPos@29
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5D2R
   x_pos: ORBITCC:rdPos@30
   y_pos: ORBITCC:rdPos@31
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6D2R
   x_pos: ORBITCC:rdPos@32
   y_pos: ORBITCC:rdPos@33
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7D2R
   x_pos: ORBITCC:rdPos@34
   y_pos: ORBITCC:rdPos@35
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1T2R
   x_pos: ORBITCC:rdPos@36
   y_pos: ORBITCC:rdPos@37
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2T2R
   x_pos: ORBITCC:rdPos@38
   y_pos: ORBITCC:rdPos@39
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3T2R
   x_pos: ORBITCC:rdPos@40
   y_pos: ORBITCC:rdPos@41
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4T2R
   x_pos: ORBITCC:rdPos@42
   y_pos: ORBITCC:rdPos@43
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ41T2R
   x_pos: ORBITCC:rdPos@44
   y_pos: ORBITCC:rdPos@45
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ42T2R
   x_pos: ORBITCC:rdPos@46
   y_pos: ORBITCC:rdPos@47
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ43T2R
   x_pos: ORBITCC:rdPos@48
   y_pos: ORBITCC:rdPos@49
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5T2R
   x_pos: ORBITCC:rdPos@50
   y_pos: ORBITCC:rdPos@51
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6T2R
   x_pos: ORBITCC:rdPos@52
   y_pos: ORBITCC:rdPos@53
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7T2R
   x_pos: ORBITCC:rdPos@54
   y_pos: ORBITCC:rdPos@55
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1D3R
   x_pos: ORBITCC:rdPos@56
   y_pos: ORBITCC:rdPos@57
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2D3R
   x_pos: ORBITCC:rdPos@58
   y_pos: ORBITCC:rdPos@59
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3D3R
   x_pos: ORBITCC:rdPos@60
   y_pos: ORBITCC:rdPos@61
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4D3R
   x_pos: ORBITCC:rdPos@62
   y_pos: ORBITCC:rdPos@63
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5D3R
   x_pos: ORBITCC:rdPos@64
   y_pos: ORBITCC:rdPos@65
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6D3R
   x_pos: ORBITCC:rdPos@66
   y_pos: ORBITCC:rdPos@67
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7D3R
   x_pos: ORBITCC:rdPos@68
   y_pos: ORBITCC:rdPos@69
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1T3R
   x_pos: ORBITCC:rdPos@70
   y_pos: ORBITCC:rdPos@71
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2T3R
   x_pos: ORBITCC:rdPos@72
   y_pos: ORBITCC:rdPos@73
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3T3R
   x_pos: ORBITCC:rdPos@74
   y_pos: ORBITCC:rdPos@75
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4T3R
   x_pos: ORBITCC:rdPos@76
   y_pos: ORBITCC:rdPos@77
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5T3R
   x_pos: ORBITCC:rdPos@78
   y_pos: ORBITCC:rdPos@79
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6T3R
   x_pos: ORBITCC:rdPos@80
   y_pos: ORBITCC:rdPos@81
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7T3R
   x_pos: ORBITCC:rdPos@82
   y_pos: ORBITCC:rdPos@83
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1D4R
   x_pos: ORBITCC:rdPos@84
   y_pos: ORBITCC:rdPos@85
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2D4R
   x_pos: ORBITCC:rdPos@86
   y_pos: ORBITCC:rdPos@87
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3D4R
   x_pos: ORBITCC:rdPos@88
   y_pos: ORBITCC:rdPos@89
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4D4R
   x_pos: ORBITCC:rdPos@90
   y_pos: ORBITCC:rdPos@91
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5D4R
   x_pos: ORBITCC:rdPos@92
   y_pos: ORBITCC:rdPos@93
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6D4R
   x_pos: ORBITCC:rdPos@94
   y_pos: ORBITCC:rdPos@95
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7D4R
   x_pos: ORBITCC:rdPos@96
   y_pos: ORBITCC:rdPos@97
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1T4R
   x_pos: ORBITCC:rdPos@98
   y_pos: ORBITCC:rdPos@99
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2T4R
   x_pos: ORBITCC:rdPos@100
   y_pos: ORBITCC:rdPos@101
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3T4R
   x_pos: ORBITCC:rdPos@102
   y_pos: ORBITCC:rdPos@103
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4T4R
   x_pos: ORBITCC:rdPos@104
   y_pos: ORBITCC:rdPos@105
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5T4R
   x_pos: ORBITCC:rdPos@106
   y_pos: ORBITCC:rdPos@107
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6T4R
   x_pos: ORBITCC:rdPos@108
   y_pos: ORBITCC:rdPos@109
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7T4R
   x_pos: ORBITCC:rdPos@110
   y_pos: ORBITCC:rdPos@111
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1D5R
   x_pos: ORBITCC:rdPos@112
   y_pos: ORBITCC:rdPos@113
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2D5R
   x_pos: ORBITCC:rdPos@114
   y_pos: ORBITCC:rdPos@115
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3D5R
   x_pos: ORBITCC:rdPos@116
   y_pos: ORBITCC:rdPos@117
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4D5R
   x_pos: ORBITCC:rdPos@118
   y_pos: ORBITCC:rdPos@119
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5D5R
   x_pos: ORBITCC:rdPos@120
   y_pos: ORBITCC:rdPos@121
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6D5R
   x_pos: ORBITCC:rdPos@122
   y_pos: ORBITCC:rdPos@123
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7D5R
   x_pos: ORBITCC:rdPos@124
   y_pos: ORBITCC:rdPos@125
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1T5R
   x_pos: ORBITCC:rdPos@126
   y_pos: ORBITCC:rdPos@127
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2T5R
   x_pos: ORBITCC:rdPos@128
   y_pos: ORBITCC:rdPos@129
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3T5R
   x_pos: ORBITCC:rdPos@130
   y_pos: ORBITCC:rdPos@131
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4T5R
   x_pos: ORBITCC:rdPos@132
   y_pos: ORBITCC:rdPos@133
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5T5R
   x_pos: ORBITCC:rdPos@134
   y_pos: ORBITCC:rdPos@135
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6T5R
   x_pos: ORBITCC:rdPos@136
   y_pos: ORBITCC:rdPos@137
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7T5R
   x_pos: ORBITCC:rdPos@138
   y_pos: ORBITCC:rdPos@139
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1D6R
   x_pos: ORBITCC:rdPos@140
   y_pos: ORBITCC:rdPos@141
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2D6R
   x_pos: ORBITCC:rdPos@142
   y_pos: ORBITCC:rdPos@143
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3D6R
   x_pos: ORBITCC:rdPos@144
   y_pos: ORBITCC:rdPos@145
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4D6R
   x_pos: ORBITCC:rdPos@146
   y_pos: ORBITCC:rdPos@147
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ41D6R
   x_pos: ORBITCC:rdPos@148
   y_pos: ORBITCC:rdPos@149
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ42D6R
   x_pos: ORBITCC:rdPos@150
   y_pos: ORBITCC:rdPos@151
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ43D6R
   x_pos: ORBITCC:rdPos@152
   y_pos: ORBITCC:rdPos@153
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ44D6R
   x_pos: ORBITCC:rdPos@154
   y_pos: ORBITCC:rdPos@155
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6D6R
   x_pos: ORBITCC:rdPos@156
   y_pos: ORBITCC:rdPos@157
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7D6R
   x_pos: ORBITCC:rdPos@158
   y_pos: ORBITCC:rdPos@159
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1T6R
   x_pos: ORBITCC:rdPos@160
   y_pos: ORBITCC:rdPos@161
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2T6R
   x_pos: ORBITCC:rdPos@162
   y_pos: ORBITCC:rdPos@163
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3T6R
   x_pos: ORBITCC:rdPos@164
   y_pos: ORBITCC:rdPos@165
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4T6R
   x_pos: ORBITCC:rdPos@166
   y_pos: ORBITCC:rdPos@167
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ41T6R
   x_pos: ORBITCC:rdPos@168
   y_pos: ORBITCC:rdPos@169
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5T6R
   x_pos: ORBITCC:rdPos@170
   y_pos: ORBITCC:rdPos@171
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6T6R
   x_pos: ORBITCC:rdPos@172
   y_pos: ORBITCC:rdPos@173
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7T6R
   x_pos: ORBITCC:rdPos@174
   y_pos: ORBITCC:rdPos@175
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1D7R
   x_pos: ORBITCC:rdPos@176
   y_pos: ORBITCC:rdPos@177
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2D7R
   x_pos: ORBITCC:rdPos@178
   y_pos: ORBITCC:rdPos@179
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3D7R
   x_pos: ORBITCC:rdPos@180
   y_pos: ORBITCC:rdPos@181
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4D7R
   x_pos: ORBITCC:rdPos@182
   y_pos: ORBITCC:rdPos@183
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5D7R
   x_pos: ORBITCC:rdPos@184
   y_pos: ORBITCC:rdPos@185
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6D7R
   x_pos: ORBITCC:rdPos@186
   y_pos: ORBITCC:rdPos@187
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7D7R
   x_pos: ORBITCC:rdPos@188
   y_pos: ORBITCC:rdPos@189
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1T7R
   x_pos: ORBITCC:rdPos@190
   y_pos: ORBITCC:rdPos@191
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2T7R
   x_pos: ORBITCC:rdPos@192
   y_pos: ORBITCC:rdPos@193
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3T7R
   x_pos: ORBITCC:rdPos@194
   y_pos: ORBITCC:rdPos@195
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4T7R
   x_pos: ORBITCC:rdPos@196
   y_pos: ORBITCC:rdPos@197
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ41T7R
   x_pos: ORBITCC:rdPos@198
   y_pos: ORBITCC:rdPos@199
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5T7R
   x_pos: ORBITCC:rdPos@200
   y_pos: ORBITCC:rdPos@201
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6T7R
   x_pos: ORBITCC:rdPos@202
   y_pos: ORBITCC:rdPos@203
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7T7R
   x_pos: ORBITCC:rdPos@204
   y_pos: ORBITCC:rdPos@205
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1D8R
   x_pos: ORBITCC:rdPos@206
   y_pos: ORBITCC:rdPos@207
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2D8R
   x_pos: ORBITCC:rdPos@208
   y_pos: ORBITCC:rdPos@209
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3D8R
   x_pos: ORBITCC:rdPos@210
   y_pos: ORBITCC:rdPos@211
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4D8R
   x_pos: ORBITCC:rdPos@212
   y_pos: ORBITCC:rdPos@213
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5D8R
   x_pos: ORBITCC:rdPos@214
   y_pos: ORBITCC:rdPos@215
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6D8R
   x_pos: ORBITCC:rdPos@216
   y_pos: ORBITCC:rdPos@217
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7D8R
   x_pos: ORBITCC:rdPos@218
   y_pos: ORBITCC:rdPos@219
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1T8R
   x_pos: ORBITCC:rdPos@220
   y_pos: ORBITCC:rdPos@221
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2T8R
   x_pos: ORBITCC:rdPos@222
   y_pos: ORBITCC:rdPos@223
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3T8R
   x_pos: ORBITCC:rdPos@224
   y_pos: ORBITCC:rdPos@225
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4T8R
   x_pos: ORBITCC:rdPos@226
   y_pos: ORBITCC:rdPos@227
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ5T8R
   x_pos: ORBITCC:rdPos@228
   y_pos: ORBITCC:rdPos@229
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ6T8R
   x_pos: ORBITCC:rdPos@230
   y_pos: ORBITCC:rdPos@231
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ7T8R
   x_pos: ORBITCC:rdPos@232
   y_pos: ORBITCC:rdPos@233
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ1D1R
   x_pos: ORBITCC:rdPos@234
   y_pos: ORBITCC:rdPos@235
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ2D1R
   x_pos: ORBITCC:rdPos@236
   y_pos: ORBITCC:rdPos@237
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ3D1R
   x_pos: ORBITCC:rdPos@238
   y_pos: ORBITCC:rdPos@239
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ4D1R
   x_pos: ORBITCC:rdPos@240
   y_pos: ORBITCC:rdPos@241
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ41D1R
   x_pos: ORBITCC:rdPos@242
   y_pos: ORBITCC:rdPos@243
-- type: pyaml.bpm.bpm
+- class: pyaml.bpm.bpm.BPM
   name: BPMZ42D1R
   x_pos: ORBITCC:rdPos@244
   y_pos: ORBITCC:rdPos@245
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1D1R
   lattice_names: Q3M1D1R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD1R:rdbk, Q3PD1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2D1R
   lattice_names: Q3M2D1R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD1R:rdbk, Q3PD1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1T1R
   lattice_names: Q3M1T1R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3P1T1R:rdbk, Q3P1T1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2T1R
   lattice_names: Q3M2T1R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3P2T1R:rdbk, Q3P2T1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1D2R
   lattice_names: Q3M1D2R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD2R:rdbk, Q3PD2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2D2R
   lattice_names: Q3M2D2R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD2R:rdbk, Q3PD2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1T2R
   lattice_names: Q3M1T2R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3PT2R:rdbk, Q3PT2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2T2R
   lattice_names: Q3M2T2R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3PT2R:rdbk, Q3PT2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1D3R
   lattice_names: Q3M1D3R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD3R:rdbk, Q3PD3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2D3R
   lattice_names: Q3M2D3R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD3R:rdbk, Q3PD3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1T3R
   lattice_names: Q3M1T3R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3PT3R:rdbk, Q3PT3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2T3R
   lattice_names: Q3M2T3R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3PT3R:rdbk, Q3PT3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1D4R
   lattice_names: Q3M1D4R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD4R:rdbk, Q3PD4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2D4R
   lattice_names: Q3M2D4R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD4R:rdbk, Q3PD4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1T4R
   lattice_names: Q3M1T4R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3PT4R:rdbk, Q3PT4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2T4R
   lattice_names: Q3M2T4R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3PT4R:rdbk, Q3PT4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1D5R
   lattice_names: Q3M1D5R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD5R:rdbk, Q3PD5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2D5R
   lattice_names: Q3M2D5R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD5R:rdbk, Q3PD5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1T5R
   lattice_names: Q3M1T5R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3PT5R:rdbk, Q3PT5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2T5R
   lattice_names: Q3M2T5R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3PT5R:rdbk, Q3PT5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1D6R
   lattice_names: Q3M1D6R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD6R:rdbk, Q3PD6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2D6R
   lattice_names: Q3M2D6R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD6R:rdbk, Q3PD6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1T6R
   lattice_names: Q3M1T6R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3P1T6R:rdbk, Q3P1T6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2T6R
   lattice_names: Q3M2T6R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3P2T6R:rdbk, Q3P2T6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1D7R
   lattice_names: Q3M1D7R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD7R:rdbk, Q3PD7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2D7R
   lattice_names: Q3M2D7R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD7R:rdbk, Q3PD7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1T7R
   lattice_names: Q3M1T7R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3PT7R:rdbk, Q3PT7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2T7R
   lattice_names: Q3M2T7R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3PT7R:rdbk, Q3PT7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1D8R
   lattice_names: Q3M1D8R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD8R:rdbk, Q3PD8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2D8R
   lattice_names: Q3M2D8R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.0158575
     unit: 1/m
     powerconverter: (Q3PD8R:rdbk, Q3PD8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M1T8R
   lattice_names: Q3M1T8R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3P1T8R:rdbk, Q3P1T8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q3M2T8R
   lattice_names: Q3M2T8R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: -0.015735
     unit: 1/m
     powerconverter: (Q3P2T8R:rdbk, Q3P2T8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1D1R
   lattice_names: Q4M1D1R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD1R:rdbk, Q4PD1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2D1R
   lattice_names: Q4M2D1R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD1R:rdbk, Q4PD1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1T1R
   lattice_names: Q4M1T1R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4P1T1R:rdbk, Q4P1T1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2T1R
   lattice_names: Q4M2T1R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4P2T1R:rdbk, Q4P2T1R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1D2R
   lattice_names: Q4M1D2R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD2R:rdbk, Q4PD2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2D2R
   lattice_names: Q4M2D2R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD2R:rdbk, Q4PD2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1T2R
   lattice_names: Q4M1T2R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4PT2R:rdbk, Q4PT2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2T2R
   lattice_names: Q4M2T2R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4PT2R:rdbk, Q4PT2R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1D3R
   lattice_names: Q4M1D3R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD3R:rdbk, Q4PD3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2D3R
   lattice_names: Q4M2D3R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD3R:rdbk, Q4PD3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1T3R
   lattice_names: Q4M1T3R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4PT3R:rdbk, Q4PT3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2T3R
   lattice_names: Q4M2T3R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4PT3R:rdbk, Q4PT3R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1D4R
   lattice_names: Q4M1D4R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD4R:rdbk, Q4PD4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2D4R
   lattice_names: Q4M2D4R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD4R:rdbk, Q4PD4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1T4R
   lattice_names: Q4M1T4R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4PT4R:rdbk, Q4PT4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2T4R
   lattice_names: Q4M2T4R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4PT4R:rdbk, Q4PT4R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1D5R
   lattice_names: Q4M1D5R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD5R:rdbk, Q4PD5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2D5R
   lattice_names: Q4M2D5R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD5R:rdbk, Q4PD5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1T5R
   lattice_names: Q4M1T5R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4PT5R:rdbk, Q4PT5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2T5R
   lattice_names: Q4M2T5R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4PT5R:rdbk, Q4PT5R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1D6R
   lattice_names: Q4M1D6R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD6R:rdbk, Q4PD6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2D6R
   lattice_names: Q4M2D6R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD6R:rdbk, Q4PD6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1T6R
   lattice_names: Q4M1T6R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4P1T6R:rdbk, Q4P1T6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2T6R
   lattice_names: Q4M2T6R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4P2T6R:rdbk, Q4P2T6R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1D7R
   lattice_names: Q4M1D7R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD7R:rdbk, Q4PD7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2D7R
   lattice_names: Q4M2D7R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD7R:rdbk, Q4PD7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1T7R
   lattice_names: Q4M1T7R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4PT7R:rdbk, Q4PT7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2T7R
   lattice_names: Q4M2T7R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4PT7R:rdbk, Q4PT7R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1D8R
   lattice_names: Q4M1D8R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD8R:rdbk, Q4PD8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2D8R
   lattice_names: Q4M2D8R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0303165
     unit: 1/m
     powerconverter: (Q4PD8R:rdbk, Q4PD8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M1T8R
   lattice_names: Q4M1T8R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4P1T8R:rdbk, Q4P1T8R:set)[A]
     hardware_unit: A
-- type: pyaml.magnet.quadrupole
+- class: pyaml.magnet.quadrupole.Quadrupole
   name: Q4M2T8R
   lattice_names: Q4M2T8R
   model:
-    type: pyaml.magnet.linear_model
+    class: pyaml.magnet.linear_model.LinearMagnetModel
     calibration_factor: 0.0296695
     unit: 1/m
     powerconverter: (Q4P2T8R:rdbk, Q4P2T8R:set)[A]
     hardware_unit: A
-- type: pyaml.diagnostics.tune_monitor
+- class: pyaml.diagnostics.tune_monitor.BetatronTuneMonitor
   name: BETATRON_TUNE
   tune_h: beam:twiss:x:tune
   tune_v: beam:twiss:y:tune
-- type: pyaml.tuning_tools.tune
+- class: pyaml.tuning_tools.tune.Tune
   name: DEFAULT_TUNE_CORRECTION
   quad_array_name: QForTune
   betatron_tune_name: BETATRON_TUNE
   response_matrix: ${path:trm.json}
-- type: pyaml.tuning_tools.tune_response_matrix
+- class: pyaml.tuning_tools.tune_response_matrix.TuneResponseMatrix
   name: DEFAULT_TUNE_RESPONSE_MATRIX
   quad_array_name: QForTune
   betatron_tune_name: BETATRON_TUNE
   quad_delta: 1e-4
-- type: pyaml.tuning_tools.chromaticity_monitor
+- class: pyaml.tuning_tools.chromaticity_monitor.ChromaticityMonitor
   name: KSI
   betatron_tune_name: BETATRON_TUNE
   rf_plant_name: RF
@@ -2449,7 +2449,7 @@ devices:
   sleep_between_step: 2
   e_delta: 1e-3
   max_e_delta: 1e-3
-- type: pyaml.tuning_tools.chromaticity_monitor
+- class: pyaml.tuning_tools.chromaticity_monitor.ChromaticityMonitor
   name: CHROMATICITY_MONITOR
   betatron_tune_name: BETATRON_TUNE
   rf_plant_name: RF

--- a/pyaml/configuration/manager.py
+++ b/pyaml/configuration/manager.py
@@ -784,7 +784,9 @@ class ConfigurationManager:
         if not isinstance(value, dict):
             return value
 
-        normalized = {key: cls._normalize_class_paths(item) for key, item in value.items()}
+        normalized = {
+            key: item if key in _INTERNAL_METADATA_KEYS else cls._normalize_class_paths(item) for key, item in value.items()
+        }
         class_path = normalized.pop("class_path", None)
         legacy_type = normalized.pop("type", None)
         class_alias = normalized.pop("class", None)

--- a/pyaml/configuration/manager.py
+++ b/pyaml/configuration/manager.py
@@ -17,6 +17,7 @@ import fnmatch
 import inspect
 import os
 import re
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -108,6 +109,9 @@ class ConfigurationManager:
         'design'
     """
 
+    DEFAULT_CLASS_PATH = "pyaml.accelerator.Accelerator"
+    # Kept as a public compatibility constant for callers using the legacy
+    # module-based manager API.
     DEFAULT_TYPE = "pyaml.accelerator"
     NAMED_CATEGORIES = ("controls", "simulators", "arrays", "devices")
     _SUPPORTED_FILE_SUFFIXES = {".yaml", ".yml", ".json"}
@@ -145,7 +149,7 @@ class ConfigurationManager:
                 inspect.Parameter.KEYWORD_ONLY,
             )
         )
-        return ("type", *fields)
+        return ("class_path", *fields)
 
     def __init__(self):
         """
@@ -154,7 +158,7 @@ class ConfigurationManager:
         The manager starts with the default accelerator type and empty named
         categories.  Source tracking is enabled as fragments are added.
         """
-        self._state: dict[str, Any] = {"type": self.DEFAULT_TYPE}
+        self._state: dict[str, Any] = {"class_path": self.DEFAULT_CLASS_PATH}
         self._items_by_category: dict[str, dict[str, dict[str, Any]]] = {category: {} for category in self.NAMED_CATEGORIES}
         self._sources_by_category: dict[str, dict[str, str]] = {category: {} for category in self.NAMED_CATEGORIES}
         self._field_sources: dict[str, str] = {}
@@ -302,7 +306,7 @@ class ConfigurationManager:
             >>> manager.clear()
         """
         if category is None:
-            self._state = {"type": self.DEFAULT_TYPE}
+            self._state = {"class_path": self.DEFAULT_CLASS_PATH}
             self._field_sources.clear()
             for name in self.NAMED_CATEGORIES:
                 self._items_by_category[name].clear()
@@ -317,9 +321,9 @@ class ConfigurationManager:
             self._sources_by_category[category].clear()
             return
 
-        if category == "type":
-            self._state["type"] = self.DEFAULT_TYPE
-            self._field_sources.pop("type", None)
+        if category in ("type", "class_path"):
+            self._state["class_path"] = self.DEFAULT_CLASS_PATH
+            self._field_sources.pop("class_path", None)
             return
 
         if category in self._state:
@@ -727,14 +731,16 @@ class ConfigurationManager:
                 f"ConfigurationManager.add() expects a mapping at the top level, got '{type(fragment).__name__}'."
             )
 
-        accelerator_type = fragment.get("type", self.DEFAULT_TYPE)
-        if accelerator_type != self.DEFAULT_TYPE:
+        prepared = self._normalize_class_paths(fragment)
+
+        accelerator_class_path = prepared.get("class_path", self.DEFAULT_CLASS_PATH)
+        if accelerator_class_path != self.DEFAULT_CLASS_PATH:
             raise UnsupportedConfigurationRootError(
-                f"ConfigurationManager only supports '{self.DEFAULT_TYPE}' roots, got '{accelerator_type}'."
+                f"ConfigurationManager only supports '{self.DEFAULT_CLASS_PATH}' roots, got '{accelerator_class_path}'."
             )
 
-        prepared = copy.deepcopy(fragment)
-        prepared["type"] = self.DEFAULT_TYPE
+        prepared = copy.deepcopy(prepared)
+        prepared["class_path"] = self.DEFAULT_CLASS_PATH
 
         for category in self.NAMED_CATEGORIES:
             if category not in prepared:
@@ -755,15 +761,52 @@ class ConfigurationManager:
                         f"Configuration category '{category}' expects named objects, "
                         f"but entry at index {index} from source '{source_name}' has no 'name'."
                     )
-                if "type" not in entry:
+                if "class_path" not in entry:
                     raise PyAMLConfigException(
-                        f"Configuration entry '{entry['name']}' in category '{category}' has no 'type'."
+                        f"Configuration entry '{entry['name']}' in category '{category}' has no 'class_path'."
                     )
 
                 if category == "simulators":
                     self._normalize_simulator_paths(entry, entry.get(REMOTE_BASE_URL_KEY, source_root))
 
         return prepared
+
+    @classmethod
+    def _normalize_class_paths(cls, value: Any) -> Any:
+        """Normalize legacy and new configuration references to ``class_path``.
+
+        Legacy ``type`` entries are resolved using their explicit ``class`` or
+        the module's ``PYAMLCLASS`` value. The manager then uses only the new
+        fully qualified ``class_path`` representation internally.
+        """
+        if isinstance(value, list):
+            return [cls._normalize_class_paths(item) for item in value]
+        if not isinstance(value, dict):
+            return value
+
+        normalized = {key: cls._normalize_class_paths(item) for key, item in value.items()}
+        class_path = normalized.pop("class_path", None)
+        legacy_type = normalized.pop("type", None)
+        legacy_class = normalized.pop("class", None)
+        if class_path is None and legacy_type is None:
+            if legacy_class is not None:
+                normalized["class"] = legacy_class
+            return normalized
+        if class_path is not None and (legacy_type is not None or legacy_class is not None):
+            raise PyAMLConfigException("Configuration cannot combine class_path with type or class.")
+        if class_path is None:
+            if not isinstance(legacy_type, str):
+                raise PyAMLConfigException(f"Invalid type '{legacy_type}'.")
+            if legacy_class is None:
+                module = import_module(legacy_type)
+                legacy_class = getattr(module, "PYAMLCLASS", None)
+                if legacy_class is None:
+                    raise PyAMLConfigException(f"Module '{legacy_type}' does not define PYAMLCLASS.")
+            class_path = f"{legacy_type}.{legacy_class}"
+        if not isinstance(class_path, str) or "." not in class_path:
+            raise PyAMLConfigException(f"Invalid class_path '{class_path}'. Expected 'module.Class'.")
+        normalized["class_path"] = class_path
+        return normalized
 
     def _merge_fragment(self, fragment: dict[str, Any], source_name: str) -> None:
         """
@@ -930,8 +973,8 @@ class ConfigurationManager:
             Formatted entry description.
         """
         name = entry.get("name", "<unnamed>")
-        entry_type = entry.get("type")
-        type_part = f" ({entry_type})" if entry_type else ""
+        entry_class_path = entry.get("class_path")
+        type_part = f" ({entry_class_path})" if entry_class_path else ""
 
         details: list[str] = []
         if category == "arrays":

--- a/pyaml/configuration/manager.py
+++ b/pyaml/configuration/manager.py
@@ -775,9 +775,9 @@ class ConfigurationManager:
     def _normalize_class_paths(cls, value: Any) -> Any:
         """Normalize legacy and new configuration references to ``class_path``.
 
-        Legacy ``type`` entries are resolved using their explicit ``class`` or
-        the module's ``PYAMLCLASS`` value. The manager then uses only the new
-        fully qualified ``class_path`` representation internally.
+        Legacy ``type`` entries are resolved using the module's ``PYAMLCLASS``
+        value. The modern ``class`` alias is accepted as a fully qualified
+        class path. The manager then uses only ``class_path`` internally.
         """
         if isinstance(value, list):
             return [cls._normalize_class_paths(item) for item in value]
@@ -787,22 +787,25 @@ class ConfigurationManager:
         normalized = {key: cls._normalize_class_paths(item) for key, item in value.items()}
         class_path = normalized.pop("class_path", None)
         legacy_type = normalized.pop("type", None)
-        legacy_class = normalized.pop("class", None)
+        class_alias = normalized.pop("class", None)
         if class_path is None and legacy_type is None:
-            if legacy_class is not None:
-                normalized["class"] = legacy_class
-            return normalized
-        if class_path is not None and (legacy_type is not None or legacy_class is not None):
+            if class_alias is not None:
+                # ``class`` is also supported as an alias for ``class_path``.
+                class_path = class_alias
+                class_alias = None
+            else:
+                return normalized
+        if class_path is not None and (legacy_type is not None or class_alias is not None):
             raise PyAMLConfigException("Configuration cannot combine class_path with type or class.")
         if class_path is None:
             if not isinstance(legacy_type, str):
                 raise PyAMLConfigException(f"Invalid type '{legacy_type}'.")
-            if legacy_class is None:
+            if class_alias is None:
                 module = import_module(legacy_type)
-                legacy_class = getattr(module, "PYAMLCLASS", None)
-                if legacy_class is None:
+                class_alias = getattr(module, "PYAMLCLASS", None)
+                if class_alias is None:
                     raise PyAMLConfigException(f"Module '{legacy_type}' does not define PYAMLCLASS.")
-            class_path = f"{legacy_type}.{legacy_class}"
+            class_path = f"{legacy_type}.{class_alias}"
         if not isinstance(class_path, str) or "." not in class_path:
             raise PyAMLConfigException(f"Invalid class_path '{class_path}'. Expected 'module.Class'.")
         normalized["class_path"] = class_path

--- a/pyaml/validation/validator.py
+++ b/pyaml/validation/validator.py
@@ -202,6 +202,12 @@ class SchemaValidator:
 
         try:
             ConfigurationSchema.model_validate(validated_dict, extra="allow")
+            # ``class`` is accepted as a validation alias for ``class_path``
+            # by ConfigurationSchema, but schema lookup below requires the
+            # canonical key to be present in the dictionary itself.
+            if "class_path" not in validated_dict and "class" in validated_dict:
+                validated_dict = dict(validated_dict)
+                validated_dict["class_path"] = validated_dict.pop("class")
             return validated_dict
         except ValidationError:
             logger.debug("Could not validate against ConfigurationSchema.")

--- a/tests/common/test_errors.py
+++ b/tests/common/test_errors.py
@@ -25,7 +25,7 @@ def test_tune(install_test_package):
         ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_3.yaml", include_locations=True, validate=True)
     assert "Configuration entry 'BPM_C04-06' is duplicated inside category 'devices'" in str(exc.value)
     assert "bad_conf_duplicate_3.yaml" in str(exc.value)
-    assert "line 43, column 3" in str(exc.value)
+    assert "line 37, column 3" in str(exc.value)
 
     with pytest.raises(PyAMLConfigException) as exc:
         ml: Accelerator = Accelerator.load("tests/config/bad_conf_duplicate_4.yaml", include_locations=True, validate=False)
@@ -50,12 +50,12 @@ def test_tune(install_test_package):
 def test_duplicate_error_reports_source_line_and_column_across_files(tmp_path):
     devices_a = tmp_path / "devices_a.yaml"
     devices_a.write_text(
-        "- type: test.device\n  name: BPM_DUPLICATE\n",
+        "- type: pyaml.bpm.bpm\n  name: BPM_DUPLICATE\n",
         encoding="utf-8",
     )
     devices_b = tmp_path / "devices_b.yaml"
     devices_b.write_text(
-        "- type: test.device\n  name: BPM_UNIQUE\n- type: test.device\n  name: BPM_DUPLICATE\n",
+        "- type: pyaml.bpm.bpm\n  name: BPM_UNIQUE\n- type: pyaml.bpm.bpm\n  name: BPM_DUPLICATE\n",
         encoding="utf-8",
     )
     root = tmp_path / "root.yaml"

--- a/tests/config/bad_conf_duplicate_3.yaml
+++ b/tests/config/bad_conf_duplicate_3.yaml
@@ -24,25 +24,17 @@ arrays:
 devices:
 - type: pyaml.bpm.bpm
   name: BPM_C04-04
-  model:
-    type: pyaml.bpm.bpm_simple_model
-    x_pos: srdiag/bpm/c04-04/SA_HPosition
-    y_pos: srdiag/bpm/c04-04/SA_VPosition
+  x_pos: srdiag/bpm/c04-04/SA_HPosition
+  y_pos: srdiag/bpm/c04-04/SA_VPosition
 - type: pyaml.bpm.bpm
   name: BPM_C04-05
-  model:
-    type: pyaml.bpm.bpm_simple_model
-    x_pos: srdiag/bpm/c04-05/SA_HPosition
-    y_pos: srdiag/bpm/c04-05/SA_VPosition
+  x_pos: srdiag/bpm/c04-05/SA_HPosition
+  y_pos: srdiag/bpm/c04-05/SA_VPosition
 - type: pyaml.bpm.bpm
   name: BPM_C04-06
-  model:
-    type: pyaml.bpm.bpm_simple_model
-    x_pos: srdiag/bpm/c04-06/SA_HPosition
-    y_pos: srdiag/bpm/c04-06/SA_VPosition
+  x_pos: srdiag/bpm/c04-06/SA_HPosition
+  y_pos: srdiag/bpm/c04-06/SA_VPosition
 - type: pyaml.bpm.bpm # duplicate device
   name: BPM_C04-06
-  model:
-    type: pyaml.bpm.bpm_simple_model
-    x_pos: srdiag/bpm/c04-06/SA_HPosition
-    y_pos: srdiag/bpm/c04-06/SA_VPosition
+  x_pos: srdiag/bpm/c04-06/SA_HPosition
+  y_pos: srdiag/bpm/c04-06/SA_VPosition

--- a/tests/configuration/test_configuration_manager.py
+++ b/tests/configuration/test_configuration_manager.py
@@ -103,7 +103,7 @@ def test_configuration_manager_clear_category_and_settings(
     result = manager.clear()
 
     assert result is None
-    assert manager.to_dict() == {"type": "pyaml.accelerator"}
+    assert manager.to_dict() == {"class_path": "pyaml.accelerator.Accelerator"}
 
 
 def test_configuration_manager_settings_follow_accelerator_config_model_order():
@@ -121,7 +121,7 @@ def test_configuration_manager_settings_follow_accelerator_config_model_order():
     )
 
     assert list(manager.settings()) == [
-        "type",
+        "class_path",
         "facility",
         "machine",
         "energy",
@@ -187,10 +187,10 @@ def test_configuration_manager_accumulates_multiple_device_fragments(
     assert manager.has("devices", "BPM_C04-01")
     assert manager.has("devices", "BPM_C04-02")
     assert manager.has("devices", "BETATRON_TUNE")
-    assert manager.get("devices", "QF1A-C01")["type"] == "pyaml.magnet.quadrupole"
-    assert manager.get("devices", "SH1A-C01")["type"] == "pyaml.magnet.cfm_magnet"
-    assert manager.get("devices", "BPM_C04-01")["type"] == "pyaml.bpm.bpm"
-    assert manager.get("devices", "BETATRON_TUNE")["type"] == "pyaml.diagnostics.tune_monitor"
+    assert manager.get("devices", "QF1A-C01")["class_path"] == "pyaml.magnet.quadrupole.Quadrupole"
+    assert manager.get("devices", "SH1A-C01")["class_path"] == "pyaml.magnet.cfm_magnet.CombinedFunctionMagnet"
+    assert manager.get("devices", "BPM_C04-01")["class_path"] == "pyaml.bpm.bpm.BPM"
+    assert manager.get("devices", "BETATRON_TUNE")["class_path"] == "pyaml.diagnostics.tune_monitor.BetatronTuneMonitor"
 
 
 def test_accelerator_load_stays_compatible(config_manager_base_config):
@@ -270,10 +270,10 @@ def test_configuration_manager_repr_is_yellow_pages_like(
     assert "Simulators:" in output
     assert "Arrays:" in output
     assert "Devices:" in output
-    assert "live (tango.pyaml.controlsystem) source=config_manager_sr_base.yaml" in output
-    assert "design (pyaml.lattice.simulator) source=config_manager_sr_base.yaml" in output
-    assert "HCORR (pyaml.arrays.magnet) patterns=1 source=config_manager_sr_arrays.yaml" in output
-    assert "BPM_C04-01 (pyaml.bpm.bpm) source=config_manager_sr_devices.yaml" in output
+    assert "live (tango.pyaml.controlsystem.TangoControlSystem) source=config_manager_sr_base.yaml" in output
+    assert "design (pyaml.lattice.simulator.Simulator) source=config_manager_sr_base.yaml" in output
+    assert "HCORR (pyaml.arrays.magnet.Magnet) patterns=1 source=config_manager_sr_arrays.yaml" in output
+    assert "BPM_C04-01 (pyaml.bpm.bpm.BPM) source=config_manager_sr_devices.yaml" in output
     assert "    ." in output
 
 
@@ -288,5 +288,5 @@ def test_configuration_manager_yellow_pages_like_shortcuts(
     manager.add(sr_devices_fragment)
 
     assert manager["BPM_C04*"] == ["BPM_C04-01", "BPM_C04-02"]
-    assert manager.HCORR["type"] == "pyaml.arrays.magnet"
+    assert manager.HCORR["class_path"] == "pyaml.arrays.magnet.Magnet"
     assert manager.simulators == ["design"]


### PR DESCRIPTION
I have made the updates so the default key in the configuration is class_path/class instead of type. Type is still supported so configuration files which are using the old format still is possible to load.

I could only change the BESSY II example for now since the others need PR https://github.com/python-accelerator-middle-layer/tango-pyaml/pull/35 to be merged before they can be validated.

I also didn't change the configurations in the tests for now to avoid breaking it before the hackathon. For now I mostly want to update the files that users might look at to learn how to write the configuration so they learn the new format.