### PR TITLE
Fix typing for _fill_device() methods

### DIFF
--- a/pyaml/bpm/bpm.py
+++ b/pyaml/bpm/bpm.py
@@ -1,12 +1,15 @@
 """Beam-position monitor elements and their runtime interfaces."""
 
 import copy
-from typing import Self
+from typing import TYPE_CHECKING, Self
 
 from ..common.abstract import ReadFloatArray, ReadWriteFloatArray, ReadWriteFloatScalar
 from ..common.element import Element, __pyaml_repr__
 from ..common.exception import PyAMLException
 from ..validation import DynamicValidation, register_schema
+
+if TYPE_CHECKING:
+    from ..common.holders.element_holder import ElementHolder
 
 PYAMLCLASS = "BPM"
 
@@ -176,7 +179,7 @@ class BPM(Element, DynamicValidation):
         obj._peer = peer
         return obj
 
-    def _fill_device(self, holder) -> None:
+    def _fill_device(self, holder: "ElementHolder") -> None:
         holder._fill_bpm(self)
 
     def get_pos_devices(self) -> list[str | None]:

--- a/pyaml/common/element.py
+++ b/pyaml/common/element.py
@@ -268,6 +268,12 @@ class Element:
         """
         return "None" if self._peer is None else f"{self._peer.__class__.__name__}:{self._peer.name()}"
 
+    def _fill_device(self, holder: "ElementHolder"):
+        """
+        Add this element to a holder (Simultor or ControlSystem)
+        """
+        raise PyAMLException(f"__fill_device() is not implemented for {self.__class__.__name__}")
+
     def post_init(self):
         """
         Perform post-construction initialization after attachment.

--- a/pyaml/configuration/unbound_element.py
+++ b/pyaml/configuration/unbound_element.py
@@ -6,10 +6,15 @@ control modes in which it is available until an :class:`ElementHolder` is
 known and the concrete element can be instantiated.
 """
 
+from typing import TYPE_CHECKING
+
 from pydantic import BaseModel
 
 from ..common.element import Element
 from ..common.exception import PyAMLConfigException
+
+if TYPE_CHECKING:
+    from ..common.holders.element_holder import ElementHolder
 
 
 class UnboundElement(Element):
@@ -54,7 +59,7 @@ class UnboundElement(Element):
             self._module_name,
         )
 
-    def _fill_device(self, holder) -> None:
+    def _fill_device(self, holder: "ElementHolder") -> None:
         holder._fill_unbound_element(self)
 
     def instantiate(self, holder) -> Element:

--- a/pyaml/diagnostics/tune_monitor.py
+++ b/pyaml/diagnostics/tune_monitor.py
@@ -6,7 +6,7 @@ and optionally converts tune fractions to frequencies using an RF plant.
 """
 
 import copy
-from typing import Self
+from typing import TYPE_CHECKING, Self
 
 from numpy.typing import NDArray
 
@@ -14,6 +14,9 @@ from ..common.abstract import ReadFloatArray
 from ..common.element import Element, __pyaml_repr__
 from ..validation import DynamicValidation, register_schema
 from .atune_monitor import ABetatronTuneMonitor
+
+if TYPE_CHECKING:
+    from ..common.holders.element_holder import ElementHolder
 
 PYAMLCLASS = "BetatronTuneMonitor"
 
@@ -90,7 +93,7 @@ class BetatronTuneMonitor(Element, DynamicValidation, ABetatronTuneMonitor):
         """
         self._h = float(h)
 
-    def _fill_device(self, holder) -> None:
+    def _fill_device(self, holder: "ElementHolder") -> None:
         holder._fill_betatron_tune_monitor(self)
 
     @property

--- a/pyaml/magnet/cfm_magnet.py
+++ b/pyaml/magnet/cfm_magnet.py
@@ -5,6 +5,8 @@ This module defines magnets that combine multiple multipole components and
 provide separate strength and hardware access for those components.
 """
 
+from typing import TYPE_CHECKING
+
 from scipy.constants import speed_of_light
 
 from ..common import abstract
@@ -23,6 +25,9 @@ from .skewoctu import SkewOctu
 from .skewquad import SkewQuad
 from .skewsext import SkewSext
 from .vcorrector import VCorrector
+
+if TYPE_CHECKING:
+    from ..common.holders.element_holder import ElementHolder
 
 _fmap: dict = {
     "B0": HCorrector,
@@ -131,7 +136,7 @@ class CombinedFunctionMagnet(Element, DynamicValidation):
             # Attach
             self._peer = peer
 
-    def _fill_device(self, holder) -> None:
+    def _fill_device(self, holder: "ElementHolder") -> None:
         holder._fill_combined_function_magnet(self)
 
     def get_model_name(self) -> str:

--- a/pyaml/magnet/magnet.py
+++ b/pyaml/magnet/magnet.py
@@ -6,7 +6,7 @@ strength, hardware, and magnet-model information.
 """
 
 import copy
-from typing import Self
+from typing import TYPE_CHECKING, Self
 
 import numpy as np
 from scipy.constants import speed_of_light
@@ -15,6 +15,9 @@ from .. import PyAMLException
 from ..common import abstract
 from ..common.element import Element
 from .model import MagnetModel
+
+if TYPE_CHECKING:
+    from ..common.holders.element_holder import ElementHolder
 
 
 class Magnet(Element):
@@ -131,7 +134,7 @@ class Magnet(Element):
         obj._peer = peer
         return obj
 
-    def _fill_device(self, holder) -> None:
+    def _fill_device(self, holder: "ElementHolder") -> None:
         holder._fill_magnet(self)
 
     def set_energy(self, energy: float):

--- a/pyaml/magnet/serialized_magnet.py
+++ b/pyaml/magnet/serialized_magnet.py
@@ -4,6 +4,8 @@ Serialized magnet elements.
 This module defines magnet elements composed of multiple serialized magnets.
 """
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 from scipy.constants import speed_of_light
 
@@ -15,6 +17,9 @@ from ..validation import DynamicValidation, register_schema
 from .function_mapping import function_map
 from .magnet import Magnet
 from .model import MagnetModel
+
+if TYPE_CHECKING:
+    from ..common.holders.element_holder import ElementHolder
 
 # Define the main class name for this module
 PYAMLCLASS = "SerializedMagnets"
@@ -257,7 +262,7 @@ class SerializedMagnets(Element, DynamicValidation):
             # Attach
             self._peer = peer
 
-    def _fill_device(self, holder) -> None:
+    def _fill_device(self, holder: "ElementHolder") -> None:
         holder._fill_serialized_magnets(self)
 
     def __create_virtual_magnet(self, name: str) -> Magnet:

--- a/pyaml/rf/rf_plant.py
+++ b/pyaml/rf/rf_plant.py
@@ -7,13 +7,16 @@ voltage.
 """
 
 import copy
-from typing import Self
+from typing import TYPE_CHECKING, Self
 
 from .. import PyAMLException
 from ..common import abstract
 from ..common.element import Element, __pyaml_repr__
 from ..validation import DynamicValidation, register_schema
 from .rf_transmitter import RFTransmitter
+
+if TYPE_CHECKING:
+    from ..common.holders.element_holder import ElementHolder
 
 # Define the main class name for this module
 PYAMLCLASS = "RFPlant"
@@ -115,7 +118,7 @@ class RFPlant(Element, DynamicValidation):
         obj._peer = peer
         return obj
 
-    def _fill_device(self, holder) -> None:
+    def _fill_device(self, holder: "ElementHolder") -> None:
         holder._fill_rf_plant(self)
 
 


### PR DESCRIPTION
This PR fix typing for `_fill_device()` methods and also add a super method in `Element` to inform developers who may forget to implement it. It also allow better code introspection.
