### PR TITLE
Change anyOf to oneOf in JSON Schema

### DIFF
--- a/pyaml/validation/generator.py
+++ b/pyaml/validation/generator.py
@@ -230,7 +230,7 @@ class RegistryJsonSchema(GenerateJsonSchema):
         subschemas = [self.generate_inner(item.__pydantic_core_schema__) for item in subclasses]
 
         # TODO: get the schemas to work when using oneOf instead
-        merged: dict[str, Any] = {"anyOf": subschemas}
+        merged: dict[str, Any] = {"oneOf": subschemas}
 
         for key in METADATA_KEYS:
             if key in base_schema and key not in merged:

--- a/tests/validation/test_generator.py
+++ b/tests/validation/test_generator.py
@@ -129,13 +129,13 @@ def test_generate_replaces_parent_schema_with_registered_subclasses(
 
     schema = SchemaGenerator.generate("pkg.module.Parent")
 
-    anyof = schema.get("anyOf", [])
-    refs = {item["$ref"] for item in anyof if "$ref" in item}
+    oneof = schema.get("oneOf", [])
+    refs = {item["$ref"] for item in oneof if "$ref" in item}
     if refs:
         assert "#/$defs/ChildSchemaA" in refs
         assert "#/$defs/ChildSchemaB" in refs
     else:
-        class_paths = {item["properties"]["class"]["const"] for item in anyof if "properties" in item}
+        class_paths = {item["properties"]["class"]["const"] for item in oneof if "properties" in item}
         assert "pkg.module.ChildA" in class_paths
         assert "pkg.module.ChildB" in class_paths
 
@@ -151,13 +151,13 @@ def test_generate_includes_real_and_virtual_subclasses(
 
     schema = SchemaGenerator.generate("pkg.module.Parent")
 
-    anyof = schema.get("anyOf", [])
-    refs = {item["$ref"] for item in anyof if "$ref" in item}
+    oneof = schema.get("oneOf", [])
+    refs = {item["$ref"] for item in oneof if "$ref" in item}
     if refs:
         assert "#/$defs/ChildSchemaA" in refs
         assert "#/$defs/VirtualChildSchema" in refs
     else:
-        class_paths = {item["properties"]["class"]["const"] for item in anyof if "properties" in item}
+        class_paths = {item["properties"]["class"]["const"] for item in oneof if "properties" in item}
         assert "pkg.module.ChildA" in class_paths
         assert "pkg.module.VirtualChild" in class_paths
 


### PR DESCRIPTION
I have changed so the JSON Schema use `oneOf` instead of `anyOf` in the JSON Schema. This should have worked before since the schema uses the classes as discriminator but I think there was a bug in the metaconfigurator which made it impossible to use.

The bug seems to be fixed now so I have updated the generator since `oneOf` is the correct option for our schemas.