### PR TITLE
Fix new holder API in tune example, removed catalog which is the default

### DIFF
--- a/examples/use_cases/01-tune_correction.ipynb
+++ b/examples/use_cases/01-tune_correction.ipynb
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "33d2cb2c",
    "metadata": {},
    "outputs": [
@@ -248,7 +248,7 @@
     }
    ],
    "source": [
-    "qcorrectors = SR.get_magnets(\"QForTune\")\n",
+    "qcorrectors = SR.magnets.get(\"QForTune\")\n",
     "first_q = qcorrectors[0]\n",
     "print(f\"The ring has {len(qcorrectors)} quadrupolar correctors. First: {first_q.get_name()}\")\n",
     "qcorrectors[0]  # string representation"
@@ -566,7 +566,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "jlp-py312",
    "language": "python",
    "name": "python3"
   },
@@ -580,7 +580,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/examples/use_cases/config/bessy2/bessy2.yaml
+++ b/examples/use_cases/config/bessy2/bessy2.yaml
@@ -9,10 +9,8 @@ simulators:
 controls:
 - class: pyaml_cs_oa.controlsystem.OphydAsyncControlSystem
   prefix: 'pons:'
+  backend: "EPICS"
   name: live
-  catalog:
-    class: pyaml_cs_oa.dynamic_catalog.DynamicCatalog
-    backend: epics
 data_folder: /data/store
 arrays:
 - class: pyaml.arrays.magnet.Magnet


### PR DESCRIPTION
This PR fix new holder API (get_magnets) in tune exmaple and use default dynamic catalog.
Require: https://github.com/python-accelerator-middle-layer/pyaml-cs-oa/pull/49