### PR TITLE
Modified dependencies because pypi didn't accept direct dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ cs-oa-tango = [
 test = [
     "pytest>=7.4",
     "pytest-cov>=3.0",
-    "pyaml-test-lattice @ git+https://github.com/python-accelerator-middle-layer/pyaml-test-lattice.git@main",
+    "pyaml-test-lattice",
 ]
 doc = [
     "sphinx ~= 8.1",


### PR DESCRIPTION
I made the release but PyPI didn't accept having direct dependencies in the pyproject.toml.